### PR TITLE
[DiscordEdit] Fix `no parameter named type` error.

### DIFF
--- a/discordedit/editautomod.py
+++ b/discordedit/editautomod.py
@@ -85,7 +85,7 @@ class AutoModRuleActionsConverter(commands.Converter):
             try:
                 discord.AutoModAction
                 automod_action = discord.AutoModRuleAction.from_data(
-                    type=action_type, data=action_dict["data"]
+                    data=action_dict["data"]
                 )
             except (TypeError, ValueError, KeyError):
                 raise commands.BadArgument(_("Invalid action metadata."))


### PR DESCRIPTION
as you can see in here the `discord.AutoModRuleAction.from_data` does not have a type param