### PR TITLE
[LinkQuoter] Use a correct description for `[p]setlinkquoter webhooks`.

### DIFF
--- a/linkquoter/linkquoter.py
+++ b/linkquoter/linkquoter.py
@@ -73,7 +73,7 @@ class LinkQuoter(Cog):
             },
             "webhooks": {
                 "converter": bool,
-                "description": "Toggle showing the original Author of the quote instead of the bot when quoting",
+                "description": "Toggle sending message with the name and avatar of the Author of the quote (with webhooks)",
                 "aliases": ["webhook"],
             },
             "cross_server": {

--- a/linkquoter/linkquoter.py
+++ b/linkquoter/linkquoter.py
@@ -73,7 +73,7 @@ class LinkQuoter(Cog):
             },
             "webhooks": {
                 "converter": bool,
-                "description": "Toggle deleting of messages for automatic quoting.\n\nIf automatic quoting is enabled, then [botname] will also delete messages that contain links in them.",
+                "description": "Toggle showing the original Author of the quote instead of the bot when quoting",
                 "aliases": ["webhook"],
             },
             "cross_server": {


### PR DESCRIPTION
Corrected information for webhook option under setlinkquoter