### PR TITLE
[GetDocs] Update `warcraftapi` documentation source to new warcraft wiki.

### DIFF
--- a/getdocs/getdocs.py
+++ b/getdocs/getdocs.py
@@ -1243,19 +1243,18 @@ class Source:
                     fields_labels = soup.find_all("span", class_="mw-headline")
                     fields_values = soup.find_all("dl")
                     for field_value in fields_values.copy():
-                        if field_value.name == "dl":
-                            text = self._get_text(
-                                field_value, parsed_url=self.url.split("/wiki")[0]
-                            )
-                            if (
-                                len(text.split("\n\n")) > 1
-                                or "WoW API" in text
-                                or "Hyperlinks" in text
-                                or "mainline" in text
-                                or "Wowprogramming" in text
-                                or "Townlong Yak" in text
-                            ):
-                                fields_values.remove(field_value)
+                        text = self._get_text(
+                            field_value, parsed_url=self.url.split("/wiki")[0]
+                        )
+                        if (
+                            len(text.split("\n\n")) > 1
+                            or "WoW API" in text
+                            or "Hyperlinks" in text
+                            or "mainline" in text
+                            or "Wowprogramming" in text
+                            or "Townlong Yak" in text
+                        ):
+                            fields_values.remove(field_value)
                     used_fields_values = set()
                     for field_label in fields_labels:
                         if field_label.text.strip().lower() in ("patch changes"):
@@ -1271,7 +1270,7 @@ class Source:
                         lines = _field_value.split("\n")
                         field_value = (
                             "".join(
-                                f"**{line.strip()}**\n"
+                                f"**•** **{line.strip()}**\n"
                                 if i % 2 == 0
                                 else f"> {line.split(' - ')[0].strip()}{' - ' if line.split(' - ')[1:] else ''}{' - '.join(line.split(' - ')[1:]).strip()}\n"
                                 for i, line in enumerate(lines)

--- a/getdocs/getdocs.py
+++ b/getdocs/getdocs.py
@@ -1241,9 +1241,9 @@ class Source:
                 fields = {}
                 try:
                     fields_labels = soup.find_all("span", class_="mw-headline")
-                    fields_values = soup.find_all(("dl", "ul"))
+                    fields_values = soup.find_all("dl")
                     for field_value in fields_values.copy():
-                        if field_value.name == "ul":
+                        if field_value.name == "dl":
                             text = self._get_text(
                                 field_value, parsed_url=self.url.split("/wiki")[0]
                             )

--- a/getdocs/getdocs.py
+++ b/getdocs/getdocs.py
@@ -205,8 +205,8 @@ BASE_URLS: typing.Dict[str, typing.Dict[str, typing.Any]] = {
         "aliases": ["ws"],
     },
     "warcraftapi": {  # Special source.
-        "url": "https://wowpedia.fandom.com/wiki/World_of_Warcraft_API",
-        "icon_url": "https://static.wikia.nocookie.net/wowpedia/images/e/e6/Site-logo.png",
+        "url": "https://warcraft.wiki.gg/wiki/World_of_Warcraft_API",
+        "icon_url": "https://warcraft.wiki.gg/images/e/e6/Site-logo.png",
         "aliases": ["warcraft"],
         "display_name": "Warcraft API",
     },


### PR DESCRIPTION
Updates the `warcraftapi` source to the newer World of Warcraft wiki since the one currently being used is deprecated.