### PR TITLE
[IP] Fix typo in `info.json`.

### DIFF
--- a/ip/info.json
+++ b/ip/info.json
@@ -2,7 +2,7 @@
     "author": ["AAA3A"],
     "name": "Ip",
     "install_msg": "This cog allows you to obtain the ip of the bot's host machine with the command `[p]ip`.",
-    "short": "A cog to get the ip adress of the bot's host machine!",
+    "short": "A cog to get the ip address of the bot's host machine!",
     "description": "A cog to get the ip address of the bot's host machine!",
     "tags": [
         "ip",


### PR DESCRIPTION
Fixes a typo in the info.json of the IP cog. Also, I had noticed that your cogs README's / docs direct support to #support_other-cogs, when you now have your own support channel. You could instead update the `docgen.py` that I gave you to direct to your channel instead.