### PR TITLE
[Minecraft] Refactor from deprecated `status.favicon` to `status.icon`.

### DIFF
--- a/minecraft/minecraft.py
+++ b/minecraft/minecraft.py
@@ -176,10 +176,10 @@ class Minecraft(Cog):
         icon_file = None
         icon = (
             discord.File(
-                icon_file := BytesIO(base64.b64decode(status.favicon.split(",", 1)[1])),
+                icon_file := BytesIO(base64.b64decode(status.icon.removeprefix("data:image/png;base64,"))),
                 filename="icon.png",
             )
-            if status.favicon
+            if status.icon
             else None
         )
         if icon:


### PR DESCRIPTION
This fixes the fairly regular occurring error:


```sh
[2025-01-03 16:04:47] [WARNING] py.warnings: /data/cogs/CogManager/cogs/minecraft/minecraft.py:182: DeprecationWarning: 'JavaStatusResponse.favicon' is deprecated and is expected to be removed on 2023-12, use 'icon' instead.

  if status.favicon

[2025-01-03 16:04:47] [WARNING] py.warnings: /data/cogs/CogManager/cogs/minecraft/minecraft.py:179: DeprecationWarning: 'JavaStatusResponse.favicon' is deprecated and is expected to be removed on 2023-12, use 'icon' instead.

  icon_file := BytesIO(base64.b64decode(status.favicon.split(",", 1)[1])),

```

Oriented by: https://mcstatus.readthedocs.io/en/stable/pages/faq/#how-to-get-server-image