### PR TITLE
[PresenceChart] Add missing requirement `kaleido`.

### DIFF
--- a/presencechart/info.json
+++ b/presencechart/info.json
@@ -10,7 +10,7 @@
         "chart",
         "graphic"
     ],
-    "requirements": ["git+https://github.com/AAA3A-AAA3A/AAA3A_utils.git", "pillow", "plotly"],
+    "requirements": ["git+https://github.com/AAA3A-AAA3A/AAA3A_utils.git", "pillow", "plotly", "kaleido"],
     "min_bot_version": "3.5.0",
     "end_user_data_statement": "This cog store the differents statuses (presence) of the users, with the starting date-time (last 100 days maximum)."
 }


### PR DESCRIPTION
Got an error when running presencechart. Seems to be a missing depedency. Just added "kaleido" as a dependency when installing.

```sh
[2025-01-05 17:27:02] [ERROR] red.AAA3A-cogs.PresenceChart: Exception in [text] command 'presencechart'.

Traceback (most recent call last):

  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped

    ret = await coro(*args, **kwargs)

          ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/data/cogs/CogManager/cogs/presencechart/presencechart.py", line 318, in presencechart

    await self.member(ctx, days_number=days_number, frame_mode=frame_mode, member=member)

  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 588, in __call__

    return await self.callback(self.cog, context, *args, **kwargs)  # type: ignore

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/data/cogs/CogManager/cogs/presencechart/presencechart.py", line 367, in member

    file: discord.File = await self.generate_chart(

                         ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/data/cogs/CogManager/cogs/presencechart/presencechart.py", line 233, in generate_chart

    graphic_bytes: bytes = fig.to_image(

                           ^^^^^^^^^^^^^

  File "/data/cogs/Downloader/lib/plotly/basedatatypes.py", line 3772, in to_image

    return pio.to_image(self, *args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/data/cogs/Downloader/lib/plotly/io/_kaleido.py", line 132, in to_image

    raise ValueError(


```