### PR TITLE
[OnePieceBounties] Fix `InteractionResponded` error in the Welcome plugin.

### DIFF
--- a/onepiecebounties/plugins/welcome.py
+++ b/onepiecebounties/plugins/welcome.py
@@ -86,10 +86,12 @@ class WelcomeView(discord.ui.View):
             return
         if interaction.user == self.member:
             await interaction.response.send_message(_("You can't toast yourself!"), ephemeral=True)
+            return 
         if interaction.user in self.toasters:
             await interaction.response.send_message(
                 _("You've already toasted this member!"), ephemeral=True
             )
+            return  
         toasts = [
             _('{user.mention} grins widely: "To {new_member.mention} joining our grand voyage!"'),
             _('{user.mention} raises a flag: "Another brave soul for our pirate crew!"'),


### PR DESCRIPTION
## Fix InteractionResponded Error in Welcome Plugin

### Problem
The `toast` method in the WelcomeView class was causing `InteractionResponded` errors because it was sending multiple responses to the same Discord interaction.

### Solution
Added missing `return` statements after error condition checks to prevent the function from continuing execution after sending an error response.

### Changes
- Added `return` after "You can't toast yourself!" response
- Added `return` after "You've already toasted this member!" response

### Testing
- [x] Verified self-toast prevention works without errors
- [x] Verified duplicate toast prevention works without errors
- [x] Confirmed successful toasts still work normally

Fixes the InteractionResponded exception mentioned in the logs.