### PR TITLE
[RumbleRoyaleUtils] Fix `RuntimeError`.

### DIFF
--- a/rumbleroyaleutils/rumbleroyaleutils.py
+++ b/rumbleroyaleutils/rumbleroyaleutils.py
@@ -107,18 +107,21 @@ class RumbleRoyaleUtils(Cog):
         elif (rumble := self.rumbles.get(message.channel)) is not None:
             if "Started a new Rumble Royale session" in embed.title:
                 rumble.first_message = await message.channel.fetch_message(rumble.first_message.id)
-                reaction = next(
-                    (
-                        reaction
-                        for reaction in rumble.first_message.reactions
-                        if isinstance(reaction.emoji, discord.PartialEmoji)
-                    ),
-                    None,
-                )
-                if reaction is None:
-                    return  # probably won't happen but good to guard anyway
+                if (
+                    reaction := next(
+                        (
+                            reaction
+                            for reaction in rumble.first_message.reactions
+                            if isinstance(reaction.emoji, discord.PartialEmoji)
+                        ),
+                        None,
+                    )
+                ) is None:
+                    return  # Shouldn't happen.
                 rumble.players = {
-                    member: [] async for member in reaction.users() if not member.bot
+                    member: []
+                    async for member in reaction.users()
+                    if not member.bot
                 }
                 # if config["am_i_alive"]:
                 #     await message.reply(


### PR DESCRIPTION
Credit to ray786 (github RayyanW786) for letting me do this PR with the changes he told me to do.
This fixes the following:
```py
[12:37:46] ERROR    [discord.client] Ignoring exception in on_message_without_command
Traceback (most recent call last):
  File "/root/.local/share/Red-DiscordBot/data/axion/cogs/CogManager/cogs/rumbleroyaleutils/rumbleroyaleutils.py", line 111, in on_message_without_command_1
    async for member in next(
                        ^^^^^
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/redenv/lib/python3.11/site-packages/discord/client.py", line 504, in _run_event
    await coro(*args, **kwargs)
RuntimeError: coroutine raised StopIteration
```