### PR TITLE
[Security] Fix an `AttributeError`.

### DIFF
--- a/security/modules/logging.py
+++ b/security/modules/logging.py
@@ -1516,7 +1516,6 @@ class LoggingModule(Module):
             emoji="🔢",
             count=len(payload.message_ids),
         )
-        file = None
         if payload.cached_messages:
             messages = payload.cached_messages
             raw_messages = [
@@ -1536,7 +1535,6 @@ class LoggingModule(Module):
                 if len(embed.description) + 8 + sum(map(len, to_include)) + len(message) <= 4000:
                     to_include.insert(0, message)
             embed.description += box("\n".join(to_include))
-        if file is not None:
             await self.send_log(channel, embed=embed, file=file)
         else:
             await self.send_log(channel, embed=embed)


### PR DESCRIPTION
This PR fixes the following AttributeError:
```py
#22223 [2026-01-02 19:27:24] ERROR [discord.client] Ignoring exception in on_raw_bulk_message_delete.
Traceback (most recent call last):
File "{HOME}/redenv/lib/python3.11/site-packages/discord/client.py", line 504, in _run_event
await coro(*args, **kwargs)
File "{HOME}/.local/share/Red-DiscordBot/data/axion/cogs/CogManager/cogs/security/modules/logging.py", line 1532, in on_raw_bulk_message_delete
await self.send_log(channel, embed=embed, file=file)
File "{HOME}/.local/share/Red-DiscordBot/data/axion/cogs/CogManager/cogs/security/modules/logging.py", line 1287, in send_log
return await webhook.send(
^^^^^^^^^^^^^^^^^^^
File "{HOME}/redenv/lib/python3.11/site-packages/discord/webhook/async_.py", line 1878, in send
with handle_message_parameters(
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/redenv/lib/python3.11/site-packages/discord/http.py", line 257, in handle_message_parameters
attachments_payload.append(attachment.to_dict())
^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'to_dict'
```
I also moved `file = None` initialization to the top to avoid a redundant else clause