### PR TITLE
[Security] Fix quarantine errors interaction not found and cache invites 503.

### DIFF
--- a/security/modules/anti_impersonation.py
+++ b/security/modules/anti_impersonation.py
@@ -141,11 +141,14 @@ class AntiImpersonationModule(Module):
                 return True
             reason = _("**Anti Impersonation** - Potential impersonation detected.")
             if config["quarantine"]:
-                await self.cog.quarantine_member(
-                    member=member,
-                    reason=reason,
-                    logs=[log],
-                )
+                try:
+                    await self.cog.quarantine_member(
+                        member=member,
+                        reason=reason,
+                        logs=[log],
+                    )
+                except RuntimeError:
+                    pass
             else:
                 await self.cog.send_modlog(
                     action="notify",

--- a/security/modules/anti_nuke.py
+++ b/security/modules/anti_nuke.py
@@ -912,11 +912,14 @@ class AntiNukeModule(Module):
                 return
         reason = option_filter["reason"]()
         if config["quarantine"]:
-            await self.cog.quarantine_member(
-                member=entry.user,
-                reason=reason,
-                logs=logs,
-            )
+            try:
+                await self.cog.quarantine_member(
+                    member=entry.user,
+                    reason=reason,
+                    logs=logs,
+                )
+            except RuntimeError:
+                pass
         else:
             await self.cog.send_modlog(
                 action="notify",
@@ -927,11 +930,14 @@ class AntiNukeModule(Module):
         if "member_reason" in option_filter and entry.target != entry.user:
             member_reason = option_filter["member_reason"]()
             if config["quarantine"]:
-                await self.cog.quarantine_member(
-                    member=entry.target,
-                    reason=member_reason,
-                    logs=logs,
-                )
+                try:
+                    await self.cog.quarantine_member(
+                        member=entry.target,
+                        reason=member_reason,
+                        logs=logs,
+                    )
+                except RuntimeError:
+                    pass
             else:
                 await self.cog.send_modlog(
                     action="notify",

--- a/security/modules/auto_mod.py
+++ b/security/modules/auto_mod.py
@@ -839,12 +839,15 @@ class AutoModModule(Module):
             if await self.cog.is_moderator_or_higher(
                 message.author
             ):  # An administrator can't be timed out, and we don't want to get the staff kicked/banned.
-                await self.cog.quarantine_member(
-                    member=message.author,
-                    reason=reason,
-                    trigger_messages=trigger_messages,
-                    context_message=message,
-                )
+                try:
+                    await self.cog.quarantine_member(
+                        member=message.author,
+                        reason=reason,
+                        trigger_messages=trigger_messages,
+                        context_message=message,
+                    )
+                except RuntimeError:
+                    pass
             elif (action := filter_config["action"]) is None:
                 if self.strikes_cache[message.guild][message.author] < 3:
                     duration = await DurationConverter.convert(
@@ -910,13 +913,16 @@ class AutoModModule(Module):
                     action == "quarantine"
                     and message.author.guild.me.guild_permissions.manage_roles
                 ):
-                    await self.cog.quarantine_member(
-                        member=message.author,
-                        reason=reason,
-                        trigger_messages=trigger_messages,
-                        context_message=message,
-                        current_ctx=message,
-                    )
+                    try:
+                        await self.cog.quarantine_member(
+                            member=message.author,
+                            reason=reason,
+                            trigger_messages=trigger_messages,
+                            context_message=message,
+                            current_ctx=message,
+                        )
+                    except RuntimeError:
+                        pass
                 if action not in ("quarantine", "kick", "ban"):
                     await self.cog.send_modlog(
                         action=action,

--- a/security/modules/dank_pool_protection.py
+++ b/security/modules/dank_pool_protection.py
@@ -657,11 +657,14 @@ class DankPoolProtectionModule(Module):
             pass
         reason = option["reason"]()
         if config["quarantine"]:
-            await self.cog.quarantine_member(
-                member=member,
-                reason=reason,
-                logs=logs,
-            )
+            try:
+                await self.cog.quarantine_member(
+                    member=member,
+                    reason=reason,
+                    logs=logs,
+                )
+            except RuntimeError:
+                pass
         else:
             await self.cog.send_modlog(
                 action="notify",

--- a/security/modules/join_gate.py
+++ b/security/modules/join_gate.py
@@ -371,11 +371,14 @@ class JoinGateModule(Module):
             elif action == "ban" and member.guild.me.guild_permissions.ban_members:
                 await member.ban(reason=audit_log_reason)
             elif action == "quarantine" and member.guild.me.guild_permissions.manage_roles:
-                await self.cog.quarantine_member(
-                    member=member,
-                    reason=reason,
-                    logs=logs,
-                )
+                try:
+                    await self.cog.quarantine_member(
+                        member=member,
+                        reason=reason,
+                        logs=logs,
+                    )
+                except RuntimeError:
+                    pass
             if action not in ("quarantine", "kick", "ban"):
                 await self.cog.send_modlog(
                     action=action,

--- a/security/modules/lockdown.py
+++ b/security/modules/lockdown.py
@@ -217,21 +217,25 @@ class LockdownModule(Module):
                                 "ban_members",
                             )
                         ) and not await self.cog.is_whitelisted(member, "lockdown"):
-                            await self.cog.quarantine_member(
-                                member=member,
-                                issued_by=interaction.user,
-                                reason=_(
-                                    "**Lockdown** - Quarantined for having dangerous permissions during lockdown."
-                                ),
-                                logs=[
-                                    _(
-                                        "{member.mention} ({member}) has dangerous permissions during lockdown."
-                                    ).format(member=member)
-                                ],
-                            )
-                            config["members_with_dangerous_permissions_quarantined"].append(
-                                member.id
-                            )
+                            try:
+                                await self.cog.quarantine_member(
+                                    member=member,
+                                    issued_by=interaction.user,
+                                    reason=_(
+                                        "**Lockdown** - Quarantined for having dangerous permissions during lockdown."
+                                    ),
+                                    logs=[
+                                        _(
+                                            "{member.mention} ({member}) has dangerous permissions during lockdown."
+                                        ).format(member=member)
+                                    ],
+                                )
+                            except RuntimeError:
+                                pass
+                            else:
+                                config["members_with_dangerous_permissions_quarantined"].append(
+                                    member.id
+                                )
                     await self.config_value(
                         guild
                     ).members_with_dangerous_permissions_quarantined.set(
@@ -335,11 +339,14 @@ class LockdownModule(Module):
             len(self.action_cache[message.author]) >= 3
             and message.guild.me.guild_permissions.manage_roles
         ):
-            await self.cog.quarantine_member(
-                message.author,
-                reason=_("**Lockdown** - Several actions during lockdown."),
-                logs=self.action_cache[message.author],
-            )
+            try:
+                await self.cog.quarantine_member(
+                    message.author,
+                    reason=_("**Lockdown** - Several actions during lockdown."),
+                    logs=self.action_cache[message.author],
+                )
+            except RuntimeError:
+                pass
 
     async def on_audit_log_entry_create(self, entry: discord.AuditLogEntry) -> None:
         if entry.action not in (
@@ -474,11 +481,14 @@ class LockdownModule(Module):
             len(self.action_cache[entry.user]) >= 3
             and entry.guild.me.guild_permissions.manage_roles
         ):
-            await self.cog.quarantine_member(
-                entry.user,
-                reason=_("**Lockdown** - Several actions during lockdown."),
-                logs=self.action_cache[entry.user],
-            )
+            try:
+                await self.cog.quarantine_member(
+                    entry.user,
+                    reason=_("**Lockdown** - Several actions during lockdown."),
+                    logs=self.action_cache[entry.user],
+                )
+            except RuntimeError:
+                pass
 
     async def on_member_join(self, member: discord.Member) -> None:
         if member.bot or member.guild is None:

--- a/security/modules/lockdown.py
+++ b/security/modules/lockdown.py
@@ -348,6 +348,48 @@ class LockdownModule(Module):
             except RuntimeError:
                 pass
 
+    def _build_role_change_log(self, entry: discord.AuditLogEntry) -> str:
+        added = [r for r in entry.after.roles if r not in entry.before.roles]
+        removed = [r for r in entry.before.roles if r not in entry.after.roles]
+        parts = []
+        if added:
+            roles_str = humanize_list([f"{r.mention} (`{r}`)" for r in added])
+            parts.append(_("add the role{s} {roles}").format(
+                roles=roles_str, s="" if len(added) == 1 else "s"
+            ))
+        if removed:
+            roles_str = humanize_list([f"{r.mention} (`{r}`)" for r in removed])
+            parts.append(_("remove the role{s} {roles}").format(
+                roles=roles_str, s="" if len(removed) == 1 else "s"
+            ))
+        return _(
+            "Member {member.mention} [{member}] tried to {action} to/from the member {quarantined_member.mention} [{quarantined_member}] during lockdown."
+        ).format(
+            member=entry.user,
+            quarantined_member=entry.target,
+            action=humanize_list(parts),
+        )
+
+    async def _send_lockdown_warning(
+        self, user: discord.Member, guild: discord.Guild, description: str
+    ) -> None:
+        if self.warning_cache[user]:
+            return
+        self.warning_cache[user] = True
+        try:
+            await user.send(
+                embed=discord.Embed(
+                    title=_("{emoji} Lockdown Warning").format(emoji=Emojis.LOCKDOWN.value),
+                    description=description,
+                    color=discord.Color.red(),
+                ).set_footer(
+                    text=guild.name,
+                    icon_url=get_non_animated_asset(guild.icon),
+                )
+            )
+        except discord.HTTPException:
+            pass
+
     async def on_audit_log_entry_create(self, entry: discord.AuditLogEntry) -> None:
         if entry.action not in (
             discord.AuditLogAction.member_role_update,
@@ -367,111 +409,24 @@ class LockdownModule(Module):
                 )
             except discord.HTTPException:
                 pass
-            if not self.warning_cache[entry.user]:
-                self.warning_cache[entry.user] = True
-                try:
-                    await entry.user.send(
-                        embed=discord.Embed(
-                            title=_("{emoji} Lockdown Warning").format(
-                                emoji=Emojis.LOCKDOWN.value
-                            ),
-                            description=_(
-                                "A lockdown is currently active in this server. You are not allowed to change roles of members. **Please do not attempt to bypass this restriction.**"
-                            ),
-                            color=discord.Color.red(),
-                        ).set_footer(
-                            text=entry.guild.name,
-                            icon_url=get_non_animated_asset(entry.guild.icon),
-                        ),
-                    )
-                except discord.HTTPException:
-                    pass
-            self.action_cache[entry.user].append(
-                _(
-                    "Member {member.mention} [{member}] tried to {action} to/from the member {quarantined_member.mention} [{quarantined_member}] during lockdown."
-                ).format(
-                    member=entry.user,
-                    quarantined_member=entry.target,
-                    action=humanize_list(
-                        (
-                            [
-                                _("add the role{s} {roles}").format(
-                                    roles=humanize_list(
-                                        [
-                                            f"{role.mention} (`{role}`)"
-                                            for role in entry.after.roles
-                                            if role not in entry.before.roles
-                                        ]
-                                    ),
-                                    s=""
-                                    if len(
-                                        [
-                                            role
-                                            for role in entry.after.roles
-                                            if role not in entry.before.roles
-                                        ]
-                                    )
-                                    == 1
-                                    else "s",
-                                )
-                            ]
-                            if any(role not in entry.before.roles for role in entry.after.roles)
-                            else []
-                        )
-                        + (
-                            [
-                                _("remove the role{s} {roles}").format(
-                                    roles=humanize_list(
-                                        [
-                                            f"{role.mention} (`{role}`)"
-                                            for role in entry.before.roles
-                                            if role not in entry.after.roles
-                                        ]
-                                    ),
-                                    s=""
-                                    if len(
-                                        [
-                                            role
-                                            for role in entry.before.roles
-                                            if role not in entry.after.roles
-                                        ]
-                                    )
-                                    == 1
-                                    else "s",
-                                )
-                            ]
-                            if any(role not in entry.after.roles for role in entry.before.roles)
-                            else []
-                        )
-                    ),
-                ),
+            await self._send_lockdown_warning(
+                entry.user,
+                entry.guild,
+                _("A lockdown is currently active in this server. You are not allowed to change roles of members. **Please do not attempt to bypass this restriction.**"),
             )
+            self.action_cache[entry.user].append(self._build_role_change_log(entry))
         elif entry.action == discord.AuditLogAction.invite_create and modes["server_invites"]:
             try:
                 await entry.target.delete(
                     reason=_("Security Lockdown: Invite created during lockdown.")
                 )
-            except discord.HTTPException as e:
+            except discord.HTTPException:
                 pass
-            if not self.warning_cache[entry.user]:
-                self.warning_cache[entry.user] = True
-                try:
-                    await entry.user.send(
-                        embed=discord.Embed(
-                            title=_("{emoji} Lockdown Warning").format(
-                                emoji=Emojis.LOCKDOWN.value
-                            ),
-                            description=_(
-                                "A lockdown is currently active in this server. You are not allowed to create invites. **Please do not attempt to bypass this restriction.**"
-                            ),
-                            color=discord.Color.red(),
-                        ).set_footer(
-                            text=entry.guild.name,
-                            icon_url=get_non_animated_asset(entry.guild.icon),
-                        )
-                    )
-                except discord.HTTPException:
-                    pass
+            await self._send_lockdown_warning(
+                entry.user,
+                entry.guild,
+                _("A lockdown is currently active in this server. You are not allowed to create invites. **Please do not attempt to bypass this restriction.**"),
+            )
             self.action_cache[entry.user].append(
                 _("{user.mention} ({user}) created an invite during lockdown.").format(
                     user=entry.user

--- a/security/modules/logging.py
+++ b/security/modules/logging.py
@@ -1314,7 +1314,10 @@ class LoggingModule(Module):
                 continue
             if not guild_data.get("modules", {}).get("logging", {}).get("enabled", False):
                 continue
-            invites = await guild.invites()
+            try:
+                invites = await guild.invites()
+            except discord.HTTPException:
+                continue
             self.invites_cache[guild] = {
                 invite.code: {
                     "uses": invite.uses,

--- a/security/modules/protected_roles.py
+++ b/security/modules/protected_roles.py
@@ -250,29 +250,35 @@ class ProtectedRolesModule(Module):
                 )
             except discord.HTTPException:
                 pass
-            await self.cog.quarantine_member(
-                entry.user,
-                reason=_("**Protected Roles** - Added a protected role without permission."),
-                logs=[
-                    _(
-                        "Added the protected role {role.mention} (`{role.name}`) to {entry.target.mention} (`{entry.target}`) without permission."
-                    ).format(role=role, entry=entry)
-                    for role in to_remove
-                ],
-            )
-            if entry.target != entry.user:
+            try:
                 await self.cog.quarantine_member(
-                    entry.target,
-                    reason=_(
-                        "**Protected Roles** - Was given a protected role without permission."
-                    ),
+                    entry.user,
+                    reason=_("**Protected Roles** - Added a protected role without permission."),
                     logs=[
                         _(
-                            "The protected role {role.mention} (`{role.name}`) was added to them by {entry.user.mention} (`{entry.user}`) without permission."
+                            "Added the protected role {role.mention} (`{role.name}`) to {entry.target.mention} (`{entry.target}`) without permission."
                         ).format(role=role, entry=entry)
                         for role in to_remove
                     ],
                 )
+            except RuntimeError:
+                pass
+            if entry.target != entry.user:
+                try:
+                    await self.cog.quarantine_member(
+                        entry.target,
+                        reason=_(
+                            "**Protected Roles** - Was given a protected role without permission."
+                        ),
+                        logs=[
+                            _(
+                                "The protected role {role.mention} (`{role.name}`) was added to them by {entry.user.mention} (`{entry.user}`) without permission."
+                            ).format(role=role, entry=entry)
+                            for role in to_remove
+                        ],
+                    )
+                except RuntimeError:
+                    pass
 
 
 class WhitelistMembersSelect(discord.ui.UserSelect):

--- a/security/security.py
+++ b/security/security.py
@@ -906,11 +906,16 @@ class Security(Cog):
                             "stream": False,
                         }
                     )
-                await channel.set_permissions(
-                    quarantine_role,
-                    overwrite=discord.PermissionOverwrite(**overwrites),
-                    reason="Updating the quarantine role overwrites in the channel used by Security.",
-                )
+                try:
+                    await channel.set_permissions(
+                        quarantine_role,
+                        overwrite=discord.PermissionOverwrite(**overwrites),
+                        reason="Updating the quarantine role overwrites in the channel used by Security.",
+                    )
+                except discord.Forbidden:
+                    pass
+                except discord.HTTPException:
+                    pass
         return quarantine_role
 
     async def create_modlog_channel(

--- a/security/security.py
+++ b/security/security.py
@@ -912,8 +912,6 @@ class Security(Cog):
                         overwrite=discord.PermissionOverwrite(**overwrites),
                         reason="Updating the quarantine role overwrites in the channel used by Security.",
                     )
-                except discord.Forbidden:
-                    pass
                 except discord.HTTPException:
                     pass
         return quarantine_role

--- a/security/views.py
+++ b/security/views.py
@@ -595,14 +595,18 @@ class SettingsView(discord.ui.View):
                 "send": functools.partial(interaction.followup.send, wait=True),
             },
         )()
-        if not await CogsUtils.ConfirmationAsk(
-            fake_context,
-            _(
-                "⚠️ Are you sure you want to reset the recovery key? This will invalidate the current key and generate a new one."
-            ),
-            timeout_message=None,
-            ephemeral=True,
-        ):
+        try:
+            confirmed = await CogsUtils.ConfirmationAsk(
+                fake_context,
+                _(
+                    "⚠️ Are you sure you want to reset the recovery key? This will invalidate the current key and generate a new one."
+                ),
+                timeout_message=None,
+                ephemeral=True,
+            )
+        except discord.NotFound:
+            return
+        if not confirmed:
             return
         try:
             await self.cog.send_recovery_key(self.ctx.guild)
@@ -997,15 +1001,19 @@ class ActionsView(discord.ui.View):
                     "send": functools.partial(interaction.followup.send, wait=True),
                 },
             )()
-            if not await CogsUtils.ConfirmationAsk(
-                fake_context,
-                _("⚠️ Are you sure you want to {action} {member.mention}?").format(
-                    action=action,
-                    member=self.member,
-                ),
-                timeout_message=None,
-                ephemeral=True,
-            ):
+            try:
+                confirmed = await CogsUtils.ConfirmationAsk(
+                    fake_context,
+                    _("⚠️ Are you sure you want to {action} {member.mention}?").format(
+                        action=action,
+                        member=self.member,
+                    ),
+                    timeout_message=None,
+                    ephemeral=True,
+                )
+            except discord.NotFound:
+                return
+            if not confirmed:
                 return
         else:
             modal: discord.ui.Modal = discord.ui.Modal(

--- a/security/views.py
+++ b/security/views.py
@@ -595,18 +595,14 @@ class SettingsView(discord.ui.View):
                 "send": functools.partial(interaction.followup.send, wait=True),
             },
         )()
-        try:
-            confirmed = await CogsUtils.ConfirmationAsk(
-                fake_context,
-                _(
-                    "⚠️ Are you sure you want to reset the recovery key? This will invalidate the current key and generate a new one."
-                ),
-                timeout_message=None,
-                ephemeral=True,
-            )
-        except discord.NotFound:
-            return
-        if not confirmed:
+        if not await CogsUtils.ConfirmationAsk(
+            fake_context,
+            _(
+                "⚠️ Are you sure you want to reset the recovery key? This will invalidate the current key and generate a new one."
+            ),
+            timeout_message=None,
+            ephemeral=True,
+        ):
             return
         try:
             await self.cog.send_recovery_key(self.ctx.guild)
@@ -1001,19 +997,15 @@ class ActionsView(discord.ui.View):
                     "send": functools.partial(interaction.followup.send, wait=True),
                 },
             )()
-            try:
-                confirmed = await CogsUtils.ConfirmationAsk(
-                    fake_context,
-                    _("⚠️ Are you sure you want to {action} {member.mention}?").format(
-                        action=action,
-                        member=self.member,
-                    ),
-                    timeout_message=None,
-                    ephemeral=True,
-                )
-            except discord.NotFound:
-                return
-            if not confirmed:
+            if not await CogsUtils.ConfirmationAsk(
+                fake_context,
+                _("⚠️ Are you sure you want to {action} {member.mention}?").format(
+                    action=action,
+                    member=self.member,
+                ),
+                timeout_message=None,
+                ephemeral=True,
+            ):
                 return
         else:
             modal: discord.ui.Modal = discord.ui.Modal(


### PR DESCRIPTION
wrap all automated `quarantine_member` calls in try/except so errors are stopped
wrap `ConfirmationAsk` calls to handle expired interactions
wrap `guild.invites()` to handle 503 errors and other http errors
affects `join_gate` `auto_mod` `anti_nuke` `dank_pool_protection` `lockdown` `protected_roles` `anti_impersonation` `views` `logging`

this is all I could find, if I missed any, either tell me, or you can fix it. I did it based on the error popups I received and some searching through the files