### PR TITLE
[Reminders] Fix edited reminders alerting at wrong time bug.

### DIFF
--- a/reminders/converters.py
+++ b/reminders/converters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from redbot.core import commands  # isort:skip
 from redbot.core.i18n import Translator  # isort:skip
 import discord  # isort:skip
@@ -7,6 +9,7 @@ import asyncio
 import datetime
 import functools
 import re
+from typing import TYPE_CHECKING
 
 import dateparser
 import dateutil
@@ -35,6 +38,9 @@ from pyparsing import (
     tokenMap,
 )  # NOQA
 from recurrent.event_parser import RecurringEvent
+
+if TYPE_CHECKING:
+    from .types import Reminder
 
 _: Translator = Translator("Reminders", __file__)
 
@@ -535,7 +541,7 @@ class ContentConverter(commands.Converter):  # no longer used
 
 
 class ExistingReminderConverter(commands.Converter):
-    async def convert(self, ctx: commands.Context, argument: str) -> typing.Any:
+    async def convert(self, ctx: commands.Context, argument: str) -> "Reminder":
         cog = ctx.bot.get_cog("Reminders")
         if ctx.author.id not in cog.cache or not (reminders := cog.cache[ctx.author.id]):
             raise commands.BadArgument(_("You haven't any reminders."))

--- a/reminders/converters.py
+++ b/reminders/converters.py
@@ -9,7 +9,6 @@ import asyncio
 import datetime
 import functools
 import re
-from typing import TYPE_CHECKING
 
 import dateparser
 import dateutil
@@ -39,7 +38,7 @@ from pyparsing import (
 )  # NOQA
 from recurrent.event_parser import RecurringEvent
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from .types import Reminder
 
 _: Translator = Translator("Reminders", __file__)

--- a/reminders/reminders.py
+++ b/reminders/reminders.py
@@ -1107,7 +1107,7 @@ class Reminders(DashboardIntegration, Cog):
                         "The repeat timedelta must be greater than {minimum_repeat} minutes."
                     ).format(minimum_repeat=minimum_repeat)
                 )
-        reminder.intervals = Repeat.from_json([repeat_dict])
+        reminder.repeat = Repeat.from_json([repeat_dict])
         await reminder.save()
         await ctx.send(
             _("Your reminder **#{reminder_id}** has been successfully edited.").format(


### PR DESCRIPTION
fixes `reminder.intervals` to `reminder.repeat` in the repeat edit command, it was just setting a dead attribute that never got saved so edits did nothing

also fixed `ExistingReminderConverter` return type while i was at it

report credits: `sensei444` https://discord.com/channels/240154543684321280/1122265755350740992/1481105091481178214