### PR TITLE
[AutoTraceback] Guard against `None` fallback after `IndexError`.

### DIFF
--- a/autotraceback/autotraceback.py
+++ b/autotraceback/autotraceback.py
@@ -66,6 +66,8 @@ class AutoTraceback(DashboardIntegration, Cog):
                 _last_exception = self.tracebacks[-(index + 1)]
             except IndexError:
                 _last_exception = ctx.bot._last_exception
+        if _last_exception is None:
+            raise commands.UserFeedbackCheckFailure(_("No exception has occurred yet."))
         _last_exception = _last_exception.split("\n")
         _last_exception[0] = _last_exception[0] + (
             "" if _last_exception[0].endswith(":") else ":\n"

--- a/autotraceback/autotraceback.py
+++ b/autotraceback/autotraceback.py
@@ -57,8 +57,6 @@ class AutoTraceback(DashboardIntegration, Cog):
             - `[public]` - Whether to send the traceback to the current context. Default is `True`.
             - `[index]`  - The error index. `0` is the last one.
         """
-        if not self.tracebacks and not ctx.bot._last_exception:
-            raise commands.UserFeedbackCheckFailure(_("No exception has occurred yet."))
         if index == 0:  # Last bot exception can be set directly by cogs.
             _last_exception = ctx.bot._last_exception
         else:


### PR DESCRIPTION
Fixes the following :
```
Traceback (most recent call last):
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/core.py", line 266, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{HOME}/data/cogs/CogManager/cogs/autotraceback/autotraceback.py", line 69, in traceback
    _last_exception = _last_exception.split("\n")
                      ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1376, in invoke
    await ctx.command.invoke(ctx)
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1064, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/core.py", line 275, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'NoneType' object has no attribute 'split'
```