### PR TITLE
[Tickets] Fix persistent view registration and guild cache crashes.

### DIFF
--- a/tickets/tickets.py
+++ b/tickets/tickets.py
@@ -447,8 +447,7 @@ class Tickets(DashboardIntegration, Cog):
                 channel_id, message_id = (int(x) for x in str(message).split("-"))
                 view: CreateTicketView = CreateTicketView(cog=self, components=components)
                 self.bot.add_view(view, message_id=message_id)
-                channel = self.bot.get_channel(channel_id)
-                if channel is not None:
+                if (channel := self.bot.get_channel(channel_id)) is not None:
                     self.views[discord.PartialMessage(channel=channel, id=message_id)] = view
         view: OwnerCloseConfirmation = OwnerCloseConfirmation(cog=self)
         self.bot.add_view(view)

--- a/tickets/tickets.py
+++ b/tickets/tickets.py
@@ -432,17 +432,24 @@ class Tickets(DashboardIntegration, Cog):
                 self.tickets.setdefault(guild_id, {})[int(ticket_id)] = ticket
                 view: TicketView = TicketView(cog=self, ticket=ticket)
                 view._message = ticket.message
-                await view._update()
+                if ticket.guild is not None:
+                    await view._update()
+                else:
+                    view.members.custom_id = f"Tickets_#{ticket.id}_members"
+                    view.lock.custom_id = f"Tickets_#{ticket.id}_lock"
+                    view.claim.custom_id = f"Tickets_#{ticket.id}_claim"
+                    view.close.custom_id = f"Tickets_#{ticket.id}_close"
+                    view.approve_appeal.custom_id = f"Tickets_#{ticket.id}_approve_appeal"
                 self.bot.add_view(view, message_id=ticket.message_id)
-                self.views[ticket.message] = view
+                if ticket.message is not None:
+                    self.views[ticket.message] = view
             for message, components in guild_data["buttons_dropdowns"].items():
-                channel = self.bot.get_channel(int((str(message).split("-"))[0]))
-                if channel is None:
-                    continue
-                message_id = int((str(message).split("-"))[1])
+                channel_id, message_id = (int(x) for x in str(message).split("-"))
                 view: CreateTicketView = CreateTicketView(cog=self, components=components)
                 self.bot.add_view(view, message_id=message_id)
-                self.views[discord.PartialMessage(channel=channel, id=message_id)] = view
+                channel = self.bot.get_channel(channel_id)
+                if channel is not None:
+                    self.views[discord.PartialMessage(channel=channel, id=message_id)] = view
         view: OwnerCloseConfirmation = OwnerCloseConfirmation(cog=self)
         self.bot.add_view(view)
         self.views["OwnerCloseConfirmation"] = view

--- a/tickets/types.py
+++ b/tickets/types.py
@@ -115,7 +115,7 @@ class Ticket:
         else:
             if not self.cog.tickets[self.guild_id]:
                 del self.cog.tickets[self.guild_id]
-        await self.cog.config.guild(self.guild).tickets.clear_raw(str(self.id))
+        await self.cog.config.guild_from_id(self.guild_id).tickets.clear_raw(str(self.id))
         if self.message in self.cog.views:
             self.cog.views.pop(self.message).stop()
 


### PR DESCRIPTION
- always call `bot.add_view()` for `CreateTicketView` regardless of channel cache state
- guard `_update()` when `ticket.guild is None`, manually set custom_ids as fallback
- use `guild_from_id` in `Ticket.delete` to avoid crash when guild isn't cached