### PR TITLE
 [Reminders] Fix Ruff compatibility issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 100
 indent-width = 4
-target-version = "py312"
+target-version = "py310"
 exclude = [
     ".bzr",
     ".direnv",

--- a/reminders/types.py
+++ b/reminders/types.py
@@ -5,6 +5,7 @@ import re
 import typing
 from dataclasses import dataclass
 from io import BytesIO
+from typing import TypeAlias
 
 import aiohttp
 import dateutil
@@ -24,11 +25,6 @@ from redbot.core.utils.chat_formatting import humanize_list
 from .views import ReminderView, RepeatView, SnoozeView
 
 _: Translator = Translator("Reminders", __file__)
-
-try:
-    from typing import TypeAlias
-except ImportError:
-    pass
 
 Content: TypeAlias = dict[
     str,

--- a/reminders/types.py
+++ b/reminders/types.py
@@ -5,7 +5,6 @@ import re
 import typing
 from dataclasses import dataclass
 from io import BytesIO
-from typing import TypeAlias
 
 import aiohttp
 import dateutil
@@ -25,6 +24,11 @@ from redbot.core.utils.chat_formatting import humanize_list
 from .views import ReminderView, RepeatView, SnoozeView
 
 _: Translator = Translator("Reminders", __file__)
+
+try:
+    from typing import TypeAlias
+except ImportError:
+    pass
 
 Content: TypeAlias = dict[
     str,

--- a/reminders/types.py
+++ b/reminders/types.py
@@ -5,6 +5,7 @@ import re
 import typing
 from dataclasses import dataclass
 from io import BytesIO
+from typing import TypeAlias
 
 import aiohttp
 import dateutil
@@ -25,15 +26,11 @@ from .views import ReminderView, RepeatView, SnoozeView
 
 _: Translator = Translator("Reminders", __file__)
 
-try:
-    from typing import TypeAlias
-except ImportError:
-    pass
-type Content = dict[
+Content: TypeAlias = dict[
     str,
     str | dict[str, str | dict[str, str]],
 ]
-type Data = dict[
+Data: TypeAlias = dict[
     str,
     str | int | bool | Content | dict[str, int | str],
 ]

--- a/reminders/views.py
+++ b/reminders/views.py
@@ -22,11 +22,11 @@ class EditReminderModal(discord.ui.Modal):
     def __init__(
         self,
         parent: discord.ui.View,
-        timezone: pytz.timezone | None = pytz.timezone("UTC"),
+        timezone: pytz.BaseTzInfo | None = pytz.timezone("UTC"),
     ) -> None:
         self._parent: discord.ui.View = parent
         self.reminder = self._parent.reminder
-        self.timezone: pytz.timezone = timezone
+        self.timezone: pytz.BaseTzInfo = timezone
 
         super().__init__(title=f"Edit Reminder #{self.reminder.id}")
 

--- a/tickets/tickets.py
+++ b/tickets/tickets.py
@@ -541,7 +541,7 @@ class Tickets(DashboardIntegration, Cog):
             return
         await ticket.close(message.interaction_metadata.user)
 
-    def is_support(ignore_owner: bool = False):
+    def is_support(ignore_owner: bool = False):  # noqa: N805
         async def predicate(ctx: commands.Context | discord.Interaction) -> bool:
             bot = ctx.client if isinstance(ctx, discord.Interaction) else ctx.bot
             author = ctx.user if isinstance(ctx, discord.Interaction) else ctx.author


### PR DESCRIPTION
Fixes a `SyntaxError` when loading the Reminders cog on Python 3.11. Ruff's UP040 rule had upgraded the Content and Data type aliases to use the `type X = ...` syntax introduced in Python 3.12, which is invalid on earlier versions (3.10-3.11). Replaced with the `TypeAlias` annotation form from `typing`, which is supported from Python 3.10 onwards.
Updated `pyproject.toml` to use the minimal version of all cogs that is `py310` to not give ruff more confusions about this type alias. We will change it back once Red actually supports 3.11+
`views.py` was also using a wrong class for pytz, fixed it.
In my first commit, I had removed the `try/except` for TypeAlias, since it's guaranteed on python versions 3.10 or above, I wasn't sure if you wanted to keep it or not as it's dead code, I reverted it and kept it.