### PR TITLE
[TempRoles] Fix typo in `discord.Embed.set_author()`'s parameter name.

### DIFF
--- a/temproles/temproles.py
+++ b/temproles/temproles.py
@@ -511,7 +511,7 @@ class TempRoles(Cog):
                     ],
                 )
         elif role is not None:
-            embed.set_author(text=f"{role.name} ({role.id})", icon_url=role.icon)
+            embed.set_author(name=f"{role.name} ({role.id})", icon_url=role.icon)
             members_data = await self.config.all_members(guild=ctx.guild)
             temp_roles_members = {}
             for member_id, data in members_data.items():


### PR DESCRIPTION
`embed.set_author()` was incorrectly filled with a `text` argument instead of `name`. Fixes this error:
```py
Traceback (most recent call last):
  File "{HOME}/axion/lib/python3.11/site-packages/discord/app_commands/commands.py", line 858, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{HOME}/data/cogs/CogManager/cogs/temproles/temproles.py", line 514, in list
    embed.set_author(text=f"{role.name} ({role.id})", icon_url=role.icon)
TypeError: Embed.set_author() got an unexpected keyword argument 'text'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/hybrid.py", line 463, in _invoke_with_namespace
    value = await self._do_call(ctx, ctx.kwargs)  # type: ignore
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{HOME}/data/cogs/Downloader/lib/AAA3A_utils/cog.py", line 301, in _do_call
    await __do_call(interaction=context, params=params)
  File "{HOME}/data/cogs/Downloader/lib/AAA3A_utils/cog.py", line 301, in _do_call
    await __do_call(interaction=context, params=params)
  File "{HOME}/axion/lib/python3.11/site-packages/discord/app_commands/commands.py", line 873, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'list' raised an exception: TypeError: Embed.set_author() got an unexpected keyword argument 'text'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{HOME}/axion/lib/python3.11/site-packages/discord/ext/commands/hybrid.py", line 463, in _invoke_with_namespace
    value = await self._do_call(ctx, ctx.kwargs)  # type: ignore
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{HOME}/data/cogs/Downloader/lib/AAA3A_utils/cog.py", line 301, in _do_call
    await __do_call(interaction=context, params=params)
  File "{HOME}/data/cogs/Downloader/lib/AAA3A_utils/cog.py", line 301, in _do_call
    await __do_call(interaction=context, params=params)
  File "{HOME}/axion/lib/python3.11/site-packages/discord/app_commands/commands.py", line 873, in _do_call
    raise CommandInvokeError(self, e) from e
discord.ext.commands.errors.HybridCommandError: Hybrid command raised an error: Command 'list' raised an exception: TypeError: Embed.set_author() got an unexpected keyword argument 'text'
```