### PR TITLE
[Security] Fix I/O operation bug.

### DIFF
--- a/security/modules/unauthorized_text_channel_deletions.py
+++ b/security/modules/unauthorized_text_channel_deletions.py
@@ -258,21 +258,25 @@ class UnauthorizedTextChannelDeletionsModule(Module):
                 guild=entry.guild,
                 bot=self.cog.bot,
             )
-            file = discord.File(
-                BytesIO(transcript.encode(encoding="utf-8")),
-                filename=f"transcript-{channel.id}.html",
-            )
+            transcript_bytes: bytes = transcript.encode(encoding="utf-8")
+            transcript_filename: str = f"transcript-{channel.id}.html"
+
+            def make_file() -> discord.File:
+                return discord.File(BytesIO(transcript_bytes), filename=transcript_filename)
         else:
             embed.add_field(
                 name="\u200b",
                 value=_("No recent messages found in this channel before deletion."),
             )
-            file = None
+            transcript_bytes = None
+
+            def make_file() -> None:
+                return None
 
         await self.cog.send_in_modlog_channel(
             entry.guild,
             embed=embed,
-            file=file,
+            file=make_file(),
         )
         if config["dm_extra_owners_and_higher"]:
             extra_owners_and_higher = [entry.guild.owner] + [
@@ -283,7 +287,7 @@ class UnauthorizedTextChannelDeletionsModule(Module):
             ]
             for owner in extra_owners_and_higher:
                 try:
-                    await owner.send(embed=embed, file=file)
+                    await owner.send(embed=embed, file=make_file())
                 except discord.HTTPException:
                     continue
 

--- a/security/modules/unauthorized_text_channel_deletions.py
+++ b/security/modules/unauthorized_text_channel_deletions.py
@@ -259,19 +259,14 @@ class UnauthorizedTextChannelDeletionsModule(Module):
                 bot=self.cog.bot,
             )
             transcript_bytes: bytes = transcript.encode(encoding="utf-8")
-            transcript_filename: str = f"transcript-{channel.id}.html"
-
-            def make_file() -> discord.File:
-                return discord.File(BytesIO(transcript_bytes), filename=transcript_filename)
+            make_file = lambda: discord.File(BytesIO(transcript_bytes), filename=f"transcript-{channel.id}.html")
         else:
             embed.add_field(
                 name="\u200b",
                 value=_("No recent messages found in this channel before deletion."),
             )
             transcript_bytes = None
-
-            def make_file() -> None:
-                return None
+            make_file = lambda: None
 
         await self.cog.send_in_modlog_channel(
             entry.guild,


### PR DESCRIPTION
When a text channel was deleted and `dm_extra_owners_and_higher` was enabled, a single `discord.File` object was shared across `send_in_modlog_channel` and every `owner.send()` call in the loop. discord.py closes the underlying `BytesIO` stream after the first send, causing all DMs to raise the following error :
```py
#846 [2026-05-20 16:06:17] ERROR [discord.client] Ignoring exception in on_audit_log_entry_create.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/client.py", line 508, in _run_event
await coro(*args, **kwargs)
File "{HOME}/data/cogs/CogManager/cogs/security/modules/unauthorized_text_channel_deletions.py", line 286, in on_audit_log_entry_create
await owner.send(embed=embed, file=file)
File "{HOME}/axion/lib/python3.11/site-packages/discord/abc.py", line 1706, in send
data = await state.http.send_message(channel.id, params=params)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/http.py", line 659, in request
async with self.__session.request(method, url, **kwargs) as response:
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/client.py", line 1197, in __aenter__
self._resp = await self._coro
^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/client.py", line 548, in _request
req = self._request_class(
^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 335, in __init__
self.update_body_from_data(data)
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 560, in update_body_from_data
size = body.size
^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/multipart.py", line 917, in size
if encoding or te_encoding or part.size is None:
^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/aiohttp/payload.py", line 367, in size
position = self._value.tell()
^^^^^^^^^^^^^^^^^^
ValueError: I/O operation on closed file.
```