### PR TITLE
[Security] Fix Missing Permissions error in logging.

### DIFF
--- a/security/modules/logging.py
+++ b/security/modules/logging.py
@@ -1487,16 +1487,17 @@ class LoggingModule(Module):
         ):
             return
         responsible = message.author if message is not None else None
-        async for entry in guild.audit_logs(
-            limit=3,
-            action=discord.AuditLogAction.message_delete,
-            oldest_first=False,
-        ):
-            if entry.extra.channel.id == message_channel.id and (
-                message is None or entry.target.id == message.author.id
+        if guild.me.guild_permissions.view_audit_log:
+            async for entry in guild.audit_logs(
+                limit=3,
+                action=discord.AuditLogAction.message_delete,
+                oldest_first=False,
             ):
-                responsible = entry.user
-                break
+                if entry.extra.channel.id == message_channel.id and (
+                    message is None or entry.target.id == message.author.id
+                ):
+                    responsible = entry.user
+                    break
         embed: discord.Embed = await self.get_embed(
             guild,
             event,
@@ -1533,14 +1534,15 @@ class LoggingModule(Module):
         if not (channel := await self.check_config(guild, event, None, message_channel)):
             return
         responsible = None
-        async for entry in guild.audit_logs(
-            limit=3,
-            action=discord.AuditLogAction.message_bulk_delete,
-            oldest_first=False,
-        ):
-            if entry.target.id == payload.channel_id:
-                responsible = entry.user
-                break
+        if guild.me.guild_permissions.view_audit_log:
+            async for entry in guild.audit_logs(
+                limit=3,
+                action=discord.AuditLogAction.message_bulk_delete,
+                oldest_first=False,
+            ):
+                if entry.target.id == payload.channel_id:
+                    responsible = entry.user
+                    break
         embed: discord.Embed = await self.get_embed(guild, event, responsible, message_channel)
         embed.description += _("\n{emoji} **Count:** {count}").format(
             emoji="🔢",


### PR DESCRIPTION
this PR fixes an error in `on_raw_message_delete` and `on_raw_bulk_message_delete`, where we weren't checking if the bot had permissions to view audit logs, so this fix will prevent it from silently dying. fixes following error :
```py
#607 [2026-05-20 04:38:13] ERROR [discord.client] Ignoring exception in on_raw_message_delete.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/client.py", line 508, in _run_event
await coro(*args, **kwargs)
File "{HOME}/data/cogs/CogManager/cogs/security/modules/logging.py", line 1490, in on_raw_message_delete
async for entry in guild.audit_logs(
File "{HOME}/axion/lib/python3.11/site-packages/discord/guild.py", line 4323, in audit_logs
data, raw_entries, state, limit = await strategy(retrieve, state, limit)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/guild.py", line 4254, in _before_strategy
data = await self._state.http.get_audit_logs(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/http.py", line 772, in request
raise Forbidden(response, data)
discord.errors.Forbidden: 403 Forbidden (error code: 50013): Missing Permissions
```