### PR TITLE
[Security] Fix list index error.

### DIFF
--- a/security/modules/dank_pool_protection.py
+++ b/security/modules/dank_pool_protection.py
@@ -81,6 +81,7 @@ DANK_POOL_PROTECTION_OPTIONS: list[
             and "Pending Confirmation" in raw_message["components"][0]["components"][0]["content"]
             and len(raw_message["components"][0]["components"]) >= 3
             and "content" in raw_message["components"][0]["components"][2]
+            and "**\u23e3 " in raw_message["components"][0]["components"][2]["content"]
             and convert_amount(
                 raw_message["components"][0]["components"][2]["content"]
                 .split("**\u23e3 ")[1]


### PR DESCRIPTION
not sure how I got that error, but this PR should be fixing it.. added a guard for the "⏣" symbol, including the bold beginning. fixes following error :
```py
#559 [2026-05-20 02:05:00] ERROR [discord.client] Ignoring exception in on_message.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/client.py", line 508, in _run_event
await coro(*args, **kwargs)
File "{HOME}/data/cogs/CogManager/cogs/security/modules/dank_pool_protection.py", line 662, in on_confirmation_message
elif option["check"](message, raw_message, config):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/data/cogs/CogManager/cogs/security/modules/dank_pool_protection.py", line 85, in <lambda>
raw_message["components"][0]["components"][2]["content"]
IndexError: list index out of range
```