### PR TITLE
[Tickets] Swap followup and close's positions.

### DIFF
--- a/tickets/views.py
+++ b/tickets/views.py
@@ -536,8 +536,8 @@ class OwnerCloseConfirmation(discord.ui.View):
                 if interaction.message.embeds[0].fields
                 else None
             )
-            await ticket.close(interaction.user, reason=reason)
             await interaction.followup.send(_("❌ This ticket has been closed!"), ephemeral=True)
+            await ticket.close(interaction.user, reason=reason)
         except RuntimeError as e:
             return await interaction.followup.send(
                 f"⛔ {e}",


### PR DESCRIPTION
this PR fixes an error in `OwnerCloseConfirmation.close`, where `interaction.followup.send` was called after `ticket.close()`, when the channel already been deleted. fixes following error :
```py
#579 [2026-05-20 03:55:24] ERROR [discord.ui.view] Ignoring exception in view <OwnerCloseConfirmation timeout=None children=2> for item <Button style=<ButtonStyle.danger: 4> url=None disabled=False label='Close' emoji=<PartialEmoji animated=False name='✖️' id=None> row=None sku_id=None id=3>.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/ui/view.py", line 598, in _scheduled_task
await item.callback(interaction)
File "{HOME}/data/cogs/CogManager/cogs/tickets/views.py", line 540, in close
await interaction.followup.send(_("❌ This ticket has been closed!"), ephemeral=True)
File "{HOME}/axion/lib/python3.11/site-packages/discord/webhook/async_.py", line 1909, in send
data = await adapter.execute_webhook(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/webhook/async_.py", line 224, in request
raise NotFound(response, data)
discord.errors.NotFound: 404 Not Found (error code: 10008): Unknown Message
```