### PR TITLE
[All] Replace `datetime.UTC` (3.11) by an older version (used previously).

### DIFF
--- a/.github/workflows/scripts/syncutils.py
+++ b/.github/workflows/scripts/syncutils.py
@@ -31,7 +31,7 @@ utils_repo = Repo.clone_from(
 utils_location = utils_repo_clone_location / "AAA3A_utils"
 
 readme = README_MD_TEXT.format(
-    time=datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d %H:%M:%S %Z"),
+    time=datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z"),
     commit=utils_repo.head.commit,
 )
 

--- a/adventcalendar/adventcalendar.py
+++ b/adventcalendar/adventcalendar.py
@@ -434,7 +434,9 @@ class AdventCalendar(Cog):
         if reward["type"] == "temp_role":
             duration = datetime.timedelta(seconds=reward["duration"])
             try:
-                end_time: datetime.datetime = datetime.datetime.now(tz=datetime.UTC) + duration
+                end_time: datetime.datetime = (
+                    datetime.datetime.now(tz=datetime.timezone.utc) + duration
+                )
             except OverflowError:
                 return None, None
             end_time = end_time.replace(second=0 if end_time.second < 30 else 30)
@@ -495,7 +497,7 @@ class AdventCalendar(Cog):
                 ).format(member=member)
                 + (f" for **day {day}**!" if day is not None else " as **final reward**!"),
                 color=discord.Color.green(),
-                timestamp=datetime.datetime.now(tz=datetime.UTC),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.set_thumbnail(url=member.display_avatar)
             embed.add_field(name=_("Member:"), value=f"{member.mention} ({member.id})")
@@ -722,7 +724,7 @@ class AdventCalendar(Cog):
                 if len(opened_days) == today.day
                 else (discord.Color.orange() if opened_days else discord.Color.red())
             ),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_author(
             name=member.display_name,
@@ -764,7 +766,7 @@ class AdventCalendar(Cog):
                 if members_all_boxes_opened
                 else (discord.Color.orange() if total_boxes_opened else discord.Color.red())
             ),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.add_field(
             name=_("Total Boxes Opened:"),

--- a/botsaysgame/botsaysgame.py
+++ b/botsaysgame/botsaysgame.py
@@ -64,7 +64,7 @@ class BotSaysGame(Cog):
                 players=humanize_list([player.mention for player in players]),
                 bot=ctx.guild.me,
                 request=request,
-                timestamp=f"<t:{int((datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=time)).timestamp())}:R>",
+                timestamp=f"<t:{int((datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=time)).timestamp())}:R>",
             )
             message = await ctx.send(embed=embed, view=view)
             if view is not None:

--- a/calculator/calculator.py
+++ b/calculator/calculator.py
@@ -257,7 +257,7 @@ class Calculator(Cog):
             embed.set_thumbnail(
                 url="https://cdn.pixabay.com/photo/2017/07/06/17/13/calculator-2478633_960_720.png",
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             if ctx.guild:
                 embed.set_footer(text=ctx.guild.name, icon_url=ctx.guild.icon)
             else:

--- a/consolelogs/consolelogs.py
+++ b/consolelogs/consolelogs.py
@@ -171,7 +171,7 @@ class ConsoleLogs(DashboardIntegration, Cog):
         )
 
         self._last_console_log_sent_timestamp: int = int(
-            datetime.datetime.now(tz=datetime.UTC).timestamp(),
+            datetime.datetime.now(tz=datetime.timezone.utc).timestamp(),
         )
         self.loops.append(
             Loop(

--- a/ctrlz/converters.py
+++ b/ctrlz/converters.py
@@ -21,16 +21,16 @@ class DateTimeConverter(commands.Converter):
     async def convert(self, ctx: commands.Context, argument: str) -> datetime.datetime:
         try:
             date_time = datetime.datetime.fromisoformat(argument).replace(
-                tzinfo=datetime.UTC,
+                tzinfo=datetime.timezone.utc,
             )
         except ValueError:
             raise commands.BadArgument(
                 _("Invalid datetime format. Expected format is ISO (`YYYY-MM-DDTHH:MM:SS`)."),
             )
         if (
-            not (datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=7))
+            not (datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7))
             <= date_time
-            <= datetime.datetime.now(tz=datetime.UTC)
+            <= datetime.datetime.now(tz=datetime.timezone.utc)
         ):
             raise commands.BadArgument(_("The date must be within the last 7 days."))
         return date_time

--- a/ctrlz/ctrlz.py
+++ b/ctrlz/ctrlz.py
@@ -235,7 +235,7 @@ class CtrlZ(Cog):
         before: datetime.datetime | None = None,
         include_already_reverted: bool = True,
     ) -> list[discord.AuditLogEntry]:
-        _after = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=7)
+        _after = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7)
         after = max(after, _after) if after is not None else _after
         reverted_audit_logs = await self.config.guild(guild).reverted_audit_logs()
         return [
@@ -431,7 +431,7 @@ class CtrlZ(Cog):
                 audit_log_id
                 for audit_log_id in guild_data["reverted_audit_logs"]
                 if (
-                    datetime.datetime.now(tz=datetime.UTC)
+                    datetime.datetime.now(tz=datetime.timezone.utc)
                     - discord.utils.snowflake_time(audit_log_id)
                 )
                 < datetime.timedelta(days=7)

--- a/dev/env.py
+++ b/dev/env.py
@@ -628,11 +628,11 @@ class DevEnv(dict[str, typing.Any]):
                 # Date & Time
                 "datetime": lambda ctx: datetime,
                 "time": lambda ctx: time,
-                "utc_now": lambda ctx: datetime.datetime.now(tz=datetime.UTC),
+                "utc_now": lambda ctx: datetime.datetime.now(tz=datetime.timezone.utc),
                 "local_now": lambda ctx: datetime.datetime.now(),
                 "get_utc_now": lambda ctx: functools.partial(
                     datetime.datetime.now,
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 ),
                 "get_local_now": lambda ctx: datetime.datetime.now,
                 # Os & Sys

--- a/discordedit/editguild.py
+++ b/discordedit/editguild.py
@@ -825,7 +825,7 @@ class EditGuild(Cog):
                 title=f"Guild {guild.name} ({guild.id})",
                 color=embed_color,
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             embed.description = "\n".join(
                 [
                     f"• `{parameter}`: {repr(getattr(guild, parameters[parameter].get('attribute_name', parameter)))}"

--- a/discordedit/editrole.py
+++ b/discordedit/editrole.py
@@ -440,7 +440,7 @@ class EditRole(Cog):
                 title=f"Role {role.name} ({role.id})",
                 color=embed_color,
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             embed.description = "\n".join(
                 [
                     f"• `{parameter}`: {repr(getattr(role, parameters[parameter].get('attribute_name', parameter)))}"

--- a/discordedit/edittextchannel.py
+++ b/discordedit/edittextchannel.py
@@ -684,7 +684,7 @@ class EditTextChannel(Cog):
                 title=f"Text Channel #{channel.name} ({channel.id})",
                 color=embed_color,
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             embed.description = "\n".join(
                 [
                     f"• `{parameter}`: {repr(getattr(channel, parameters[parameter].get('attribute_name', parameter)))}"

--- a/discordedit/editthread.py
+++ b/discordedit/editthread.py
@@ -501,7 +501,7 @@ class EditThread(Cog):
                 title=f"Thread #{thread.name} ({thread.id})",
                 color=embed_color,
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             embed.description = "\n".join(
                 [
                     f"• `{parameter}`: {repr(getattr(thread, parameters[parameter].get('attribute_name', parameter)))}"

--- a/discordedit/editvoicechannel.py
+++ b/discordedit/editvoicechannel.py
@@ -588,7 +588,7 @@ class EditVoiceChannel(Cog):
                 title=f"Voice Channel #!{channel.name} ({channel.id})",
                 color=embed_color,
             )
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             embed.description = "\n".join(
                 [
                     f"• `{parameter}`: {repr(getattr(channel, parameters[parameter].get('attribute_name', parameter)))}"

--- a/disurlvotestracker/dashboard_integration.py
+++ b/disurlvotestracker/dashboard_integration.py
@@ -113,8 +113,8 @@ class DashboardIntegration:
                     [
                         vote
                         for vote in member_data["votes"]
-                        if datetime.datetime.now(tz=datetime.UTC)
-                        - datetime.datetime.fromtimestamp(vote, tz=datetime.UTC)
+                        if datetime.datetime.now(tz=datetime.timezone.utc)
+                        - datetime.datetime.fromtimestamp(vote, tz=datetime.timezone.utc)
                         < datetime.timedelta(days=30)
                     ],
                 )

--- a/disurlvotestracker/disurlvotestracker.py
+++ b/disurlvotestracker/disurlvotestracker.py
@@ -203,16 +203,16 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
         else:
             voters_role = None
 
-        utc_now = datetime.datetime.now(tz=datetime.UTC)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         start_month = datetime.datetime(
             utc_now.year,
             utc_now.month,
             1,
-            tzinfo=datetime.UTC,
+            tzinfo=datetime.timezone.utc,
         )
         member_data = await self.config.member(member).all()
         number_member_votes = len(member_data["votes"]) + 1
-        start_month = datetime.datetime.now(tz=datetime.UTC).replace(
+        start_month = datetime.datetime.now(tz=datetime.timezone.utc).replace(
             day=1,
             hour=0,
             minute=0,
@@ -224,7 +224,8 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                 [
                     vote
                     for vote in member_data["votes"]
-                    if datetime.datetime.fromtimestamp(vote, tz=datetime.UTC) >= start_month
+                    if datetime.datetime.fromtimestamp(vote, tz=datetime.timezone.utc)
+                    >= start_month
                 ],
             )
             + 1
@@ -238,7 +239,7 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                 embed: discord.Embed = discord.Embed(
                     title=_("New vote for {guild.name}!").format(guild=guild),
                     color=discord.Color.green(),
-                    timestamp=datetime.datetime.now(tz=datetime.UTC),
+                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                 )
                 embed.set_author(
                     name=member.display_name,
@@ -322,10 +323,10 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                 if member_data["last_reminder_sent"] or not (votes := member_data["votes"]):
                     continue
                 if datetime.datetime.now(
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 ) - datetime.datetime.fromtimestamp(
                     votes[-1],
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 ) < datetime.timedelta(hours=12):
                     continue
                 await self.config.member_from_ids(guild_id, member_id).last_reminder_sent.set(True)
@@ -369,7 +370,7 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                             )
                         else:
                             number_member_votes = len(member_data["votes"])
-                            start_month = datetime.datetime.now(tz=datetime.UTC).replace(
+                            start_month = datetime.datetime.now(tz=datetime.timezone.utc).replace(
                                 day=1,
                                 hour=0,
                                 minute=0,
@@ -380,7 +381,8 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                                 [
                                     vote
                                     for vote in member_data["votes"]
-                                    if datetime.datetime.now(tz=datetime.UTC) >= start_month
+                                    if datetime.datetime.now(tz=datetime.timezone.utc)
+                                    >= start_month
                                 ],
                             )
                             s_1 = "" if number_member_votes == 1 else "s"
@@ -487,7 +489,7 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
             raise commands.UserFeedbackCheckFailure(
                 _("DisurlVotesTracker is not enabled in this server."),
             )
-        start_month = datetime.datetime.now(tz=datetime.UTC).replace(
+        start_month = datetime.datetime.now(tz=datetime.timezone.utc).replace(
             day=1,
             hour=0,
             minute=0,
@@ -501,7 +503,8 @@ class DisurlVotesTracker(DashboardIntegration, Cog):
                     [
                         vote
                         for vote in member_data["votes"]
-                        if datetime.datetime.fromtimestamp(vote, tz=datetime.UTC) >= start_month
+                        if datetime.datetime.fromtimestamp(vote, tz=datetime.timezone.utc)
+                        >= start_month
                     ],
                 )
                 for member_id, member_data in members_data.items()

--- a/fastclickgame/view.py
+++ b/fastclickgame/view.py
@@ -58,7 +58,7 @@ class FastClickGameView(discord.ui.View):
             "⏳ The game will start {timestamp}, first one to click the 🟩 button wins.\n> **{rounds} round{s}** to play.",
         ).format(
             timestamp=discord.utils.format_dt(
-                datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=5),
+                datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=5),
                 "R",
             ),
             rounds=self.rounds,
@@ -102,7 +102,7 @@ class FastClickGameView(discord.ui.View):
                 winner=winner,
                 click_time=self.times[-1],
                 timestamp=discord.utils.format_dt(
-                    datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=3),
+                    datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=3),
                     "R",
                 ),
             )

--- a/gistshandler/view.py
+++ b/gistshandler/view.py
@@ -396,7 +396,7 @@ class GistsHandlerView(discord.ui.View):
             )
             return
         self._deleted: bool = True
-        self._deleted_at: datetime.datetime = datetime.datetime.now(tz=datetime.UTC)
+        self._deleted_at: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc)
         await interaction.response.send_message(
             _("Gist `{gist.id}` deleted.").format(gist=self.gist),
             ephemeral=True,

--- a/guessthecandygame/view.py
+++ b/guessthecandygame/view.py
@@ -54,7 +54,7 @@ class GuessTheCandyGameView(discord.ui.View):
             file=discord.File(self.cog.shadows[self.candy], filename="shadow.png"),
         )
         self.cog.views[self._message] = self
-        self.start_time: datetime.datetime = datetime.datetime.now(tz=datetime.UTC)
+        self.start_time: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc)
 
     async def on_timeout(self) -> None:
         for child in self.children:
@@ -88,7 +88,7 @@ class GuessTheCandyGameView(discord.ui.View):
                     "**Congratulations!** You've correctly guessed it's **{candy}**, in **{time} seconds**!",
                 ).format(
                     candy=self.candy,
-                    time=f"{(datetime.datetime.now(tz=datetime.UTC) - self.start_time).total_seconds():.2f}",
+                    time=f"{(datetime.datetime.now(tz=datetime.timezone.utc) - self.start_time).total_seconds():.2f}",
                 ),
                 color=await self.ctx.embed_color(),
             )

--- a/guildstats/guildstats.py
+++ b/guildstats/guildstats.py
@@ -150,7 +150,7 @@ class GuildStats(Cog):
         await super().cog_load()
         if await self.config.first_loading_time() is None:
             await self.config.first_loading_time.set(
-                int(datetime.datetime.now(tz=datetime.UTC).timestamp()),
+                int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()),
             )
         asyncio.create_task(self.load_data())
         self.loops.append(
@@ -457,7 +457,7 @@ class GuildStats(Cog):
 
     async def cleanup(self, utc_now: datetime.datetime = None) -> None:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         channel_group = self.config._get_base_group(self.config.CHANNEL)
         async with channel_group.all() as channels_data:
             for channel in channels_data:
@@ -543,7 +543,7 @@ class GuildStats(Cog):
         if message.author not in self.cache[message.guild]["channels"][message.channel]["messages"]:
             self.cache[message.guild]["channels"][message.channel]["messages"][message.author] = []
         self.cache[message.guild]["channels"][message.channel]["messages"][message.author].append(
-            datetime.datetime.now(tz=datetime.UTC),
+            datetime.datetime.now(tz=datetime.timezone.utc),
         )
 
     @commands.Cog.listener()
@@ -590,7 +590,7 @@ class GuildStats(Cog):
                     "voice_cache": {},
                 }
             self.cache[after.channel.guild]["channels"][after.channel]["voice_cache"][member] = (
-                datetime.datetime.now(tz=datetime.UTC)
+                datetime.datetime.now(tz=datetime.timezone.utc)
             )
         if before.channel is not None:
             if isinstance(after.channel, discord.StageChannel):
@@ -604,7 +604,7 @@ class GuildStats(Cog):
             ignored_users = await self.config.ignored_users()
             if member.id in ignored_users:
                 return
-            end_time = datetime.datetime.now(tz=datetime.UTC)
+            end_time = datetime.datetime.now(tz=datetime.timezone.utc)
             real_total_time = int((end_time - start_time).total_seconds())
             if round(real_total_time / 3600, 2) == 0:
                 return
@@ -674,7 +674,7 @@ class GuildStats(Cog):
                         "activities_cache": {},
                     }
                 self.cache[after.guild]["members"][after]["activities_cache"][activity.name] = (
-                    datetime.datetime.now(tz=datetime.UTC)
+                    datetime.datetime.now(tz=datetime.timezone.utc)
                 )
         if before is not None:
             ignored_users = await self.config.ignored_users()
@@ -694,7 +694,7 @@ class GuildStats(Cog):
                     ].pop(activity.name)
                 except KeyError:
                     return
-                end_time = datetime.datetime.now(tz=datetime.UTC)
+                end_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 real_total_time = int((end_time - start_time).total_seconds())
                 if real_total_time < 10 * 60:
                     return
@@ -746,7 +746,7 @@ class GuildStats(Cog):
         else:
             _type = None
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         # Get cache data.
         all_channels_data = {
             channel_id: data
@@ -802,7 +802,7 @@ class GuildStats(Cog):
                 # already_seen.append(member)
                 if member not in channel.members:
                     continue
-                end_time = datetime.datetime.now(tz=datetime.UTC)
+                end_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 real_total_time = int((end_time - start_time).total_seconds())
                 if round(real_total_time / 3600, 2) == 0:
                     continue
@@ -844,7 +844,7 @@ class GuildStats(Cog):
             for activity_name, start_time in data["activities_cache"].items():
                 if discord.utils.get(member.activities, name=activity_name) is None:
                     continue
-                end_time = datetime.datetime.now(tz=datetime.UTC)
+                end_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 real_total_time = int((end_time - start_time).total_seconds())
                 if real_total_time < 10 * 60:
                     continue
@@ -3803,7 +3803,7 @@ class GuildStats(Cog):
                 image = Image.open(self.icons["history"])
                 image = image.resize((50, 50))
                 img.paste(image, (30, 972, 80, 1022), mask=image.split()[3])
-                utc_now = datetime.datetime.now(tz=datetime.UTC)
+                utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
                 tracking_data_start_time = max(
                     first_loading_time,
                     (_object if isinstance(_object, discord.Guild) else _object.guild).me.joined_at,
@@ -3924,7 +3924,7 @@ class GuildStats(Cog):
             default_state=await self.config.default_state(),
             first_loading_time=datetime.datetime.fromtimestamp(
                 await self.config.first_loading_time(),
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             ),
         )
 
@@ -6057,7 +6057,7 @@ class GuildStats(Cog):
                 image = image.resize((1840, 464))
                 img.paste(image, (50, 1123, 1890, 1387 + 200))
 
-        utc_now = datetime.datetime.now(tz=datetime.UTC)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         tracking_data_start_time = max(
             first_loading_time,
             (_object if isinstance(_object, discord.Guild) else _object.guild).me.joined_at,
@@ -6243,7 +6243,7 @@ class GuildStats(Cog):
             default_state=await self.config.default_state(),
             first_loading_time=datetime.datetime.fromtimestamp(
                 await self.config.first_loading_time(),
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             ),
         )
 

--- a/karutadropleaderboard/karutadropleaderboard.py
+++ b/karutadropleaderboard/karutadropleaderboard.py
@@ -101,7 +101,7 @@ class KarutaDropLeaderboard(DashboardIntegration, Cog):
         await self.config.member(member).set(member_data)
 
     async def cleanup_last_drops(self) -> None:
-        now_timestamp = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        now_timestamp = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         for guild_id, data in (await self.config.all_members()).items():
             for member_id, member_data in data.items():
                 if "last_drops" not in member_data:
@@ -174,7 +174,7 @@ class KarutaDropLeaderboard(DashboardIntegration, Cog):
             icon_url=member.display_avatar,
         )
         member_data = await self.config.member(member).all()
-        now_timestamp = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        now_timestamp = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         embed.description = "\n".join(
             f"- {'✅' if int(drop) > (now_timestamp - 43200) else '⏲️'} {discord.utils.format_dt(datetime.datetime.fromtimestamp(int(drop)), style='R')} {message_jump_url}"
             for drop, message_jump_url in list(member_data["last_drops"].items())[-10:]

--- a/lastmentions/lastmentions.py
+++ b/lastmentions/lastmentions.py
@@ -136,7 +136,7 @@ class LastMentions(Cog):
                 retention_days = await self.config.guild_from_id(int(guild_id)).retention_days()
                 retention_timestamp = int(
                     (
-                        datetime.datetime.now(datetime.UTC)
+                        datetime.datetime.now(datetime.timezone.utc)
                         - datetime.timedelta(days=retention_days)
                     ).timestamp(),
                 )
@@ -298,7 +298,7 @@ class LastMentions(Cog):
             and (
                 created_at := datetime.datetime.fromtimestamp(
                     last_mention["timestamp"],
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 )
             )
         )
@@ -492,10 +492,14 @@ class LastMentions(Cog):
         y = []
         for i in x:
             start = int(
-                (datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=-i + 1)).timestamp(),
+                (
+                    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=-i + 1)
+                ).timestamp(),
             )
             end = int(
-                (datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=-i)).timestamp(),
+                (
+                    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=-i)
+                ).timestamp(),
             )
             y.append(
                 len(

--- a/mafiagame/game.py
+++ b/mafiagame/game.py
@@ -302,7 +302,7 @@ class Night(DayNight):
                         await self.game.cog.config.member(player.member).temp_banned_until.set(
                             int(
                                 (
-                                    datetime.datetime.now(tz=datetime.UTC)
+                                    datetime.datetime.now(tz=datetime.timezone.utc)
                                     + datetime.timedelta(hours=afk_temp_ban_duration)
                                 )
                                 .replace(second=0, microsecond=0)

--- a/mafiagame/mafiagame.py
+++ b/mafiagame/mafiagame.py
@@ -381,10 +381,10 @@ class MafiaGame(Cog):
                             "temp_banned_until",
                         )
                     ) is not None and datetime.datetime.now(
-                        tz=datetime.UTC,
+                        tz=datetime.timezone.utc,
                     ) > datetime.datetime.fromtimestamp(
                         temp_banned_until,
-                        tz=datetime.UTC,
+                        tz=datetime.timezone.utc,
                     ):
                         del members_data[guild_id][member_id]["temp_banned_until"]
 
@@ -707,7 +707,7 @@ class MafiaGame(Cog):
             raise commands.UserFeedbackCheckFailure(_("A bot can't play a Mafia game."))
         await self.config.member(member).temp_banned_until.set(
             int(
-                (datetime.datetime.now(tz=datetime.UTC) + duration)
+                (datetime.datetime.now(tz=datetime.timezone.utc) + duration)
                 .replace(second=0, microsecond=0)
                 .timestamp(),
             ),
@@ -780,9 +780,9 @@ class MafiaGame(Cog):
                     duration=humanize_timedelta(
                         timedelta=datetime.datetime.fromtimestamp(
                             temp_banned_until,
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         )
-                        - datetime.datetime.now(tz=datetime.UTC),
+                        - datetime.datetime.now(tz=datetime.timezone.utc),
                     ),
                 ),
             )

--- a/mafiagame/views.py
+++ b/mafiagame/views.py
@@ -180,9 +180,9 @@ class JoinGameView(discord.ui.View):
                     duration=humanize_timedelta(
                         timedelta=datetime.datetime.fromtimestamp(
                             temp_banned_until,
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         )
-                        - datetime.datetime.now(tz=datetime.UTC),
+                        - datetime.datetime.now(tz=datetime.timezone.utc),
                     ),
                 ),
                 ephemeral=True,
@@ -1996,7 +1996,8 @@ class PollView(JoinGameView):
                     "You are **temporarily banned for {duration}** from joining Mafia games in this server!",
                 ).format(
                     duration=humanize_timedelta(
-                        timedelta=temp_banned_until - datetime.datetime.now(tz=datetime.UTC),
+                        timedelta=temp_banned_until
+                        - datetime.datetime.now(tz=datetime.timezone.utc),
                     ),
                 ),
                 ephemeral=True,

--- a/onepiecebounties/onepiecebounties.py
+++ b/onepiecebounties/onepiecebounties.py
@@ -191,13 +191,13 @@ class OnePieceBounties(WelcomePlugin, Cog):
                     if (accurate_joined_at := await self.config.member(member).accurate_joined_at())
                     is None
                     else datetime.datetime.fromisoformat(accurate_joined_at).replace(
-                        tzinfo=datetime.UTC,
+                        tzinfo=datetime.timezone.utc,
                     )
                 )
             )
             is not None
         ):
-            months = (datetime.datetime.now(tz=datetime.UTC) - joined_at).days / 30
+            months = (datetime.datetime.now(tz=datetime.timezone.utc) - joined_at).days / 30
             for i in range(1, int(months) + 2):
                 random_obj.seed(f"{member.id}-month-{i}")
                 year = i // 12
@@ -327,7 +327,7 @@ class OnePieceBounties(WelcomePlugin, Cog):
                 bounty_tier=bounty_tier,
             ),
             color=await self.bot.get_embed_color(member),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_footer(
             text=member.guild.name,

--- a/presencechart/presencechart.py
+++ b/presencechart/presencechart.py
@@ -274,7 +274,7 @@ class PresenceChart(Cog):
                         changed_at = data[0]
                         if changed_at < int(
                             (
-                                datetime.datetime.now(tz=datetime.UTC)
+                                datetime.datetime.now(tz=datetime.timezone.utc)
                                 - datetime.timedelta(days=100)
                             ).timestamp(),
                         ):
@@ -303,7 +303,7 @@ class PresenceChart(Cog):
             status,
         ):  # Discord dispatches this event for every guild the user is in.
             return
-        time = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        time = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         self.presence_data_cache[after._user.id] = (time, (old_status, status))
 
     @commands.guild_only()
@@ -346,7 +346,7 @@ class PresenceChart(Cog):
                 member.raw_status if member.raw_status in self.presence_map else "online"
             ] = 100
         else:
-            now_time = datetime.datetime.now(tz=datetime.UTC)
+            now_time = datetime.datetime.now(tz=datetime.timezone.utc)
             if days_number is not None:
                 time_delta = now_time - datetime.timedelta(days=days_number)
                 time_delta_timestamp = int(time_delta.timestamp())

--- a/reminders/converters.py
+++ b/reminders/converters.py
@@ -132,7 +132,7 @@ class TimeConverter(commands.Converter):
         | tuple[datetime.datetime, datetime.datetime, typing.Any | None]
     ):
         cog = ctx.bot.get_cog("Reminders")
-        utc_now = datetime.datetime.now(tz=datetime.UTC).replace(second=0, microsecond=0)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc).replace(second=0, microsecond=0)
         timezone = await cog.config.user(ctx.author).timezone()
         if timezone is None:
             if (timezone_cog := ctx.bot.get_cog("Timezone")) is not None:
@@ -153,7 +153,7 @@ class TimeConverter(commands.Converter):
                 dt: datetime.datetime = dateutil.parser.isoparse(arg)
                 if dt.tzinfo is None:
                     dt = dt.replace(tzinfo=tz)
-                return dt.astimezone(tz=datetime.UTC)
+                return dt.astimezone(tz=datetime.timezone.utc)
             except ValueError as e:
                 raise ValueError(f"• Iso parsing: {' '.join(e.args)}.")
 
@@ -179,7 +179,7 @@ class TimeConverter(commands.Converter):
                     f"• Cron trigger parsing: {' '.join([f'{arg}.' for arg in e.args])}.",
                 )
             expires_at = cron_trigger.get_next_fire_time(previous_fire_time=None, now=local_now)
-            expires_at = expires_at.astimezone(tz=datetime.UTC)
+            expires_at = expires_at.astimezone(tz=datetime.timezone.utc)
             try:
                 return (
                     expires_at,
@@ -203,7 +203,7 @@ class TimeConverter(commands.Converter):
         def parse_timestamp(arg: str) -> datetime.datetime:
             try:
                 timestamp = float(arg)
-                expires_at = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC)
+                expires_at = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
             except (ValueError, OverflowError) as e:
                 raise ValueError(
                     f"• Timestamp parsing: {' '.join([f'{e_arg}.' for e_arg in e.args])}.",
@@ -276,7 +276,7 @@ class TimeConverter(commands.Converter):
                 except OverflowError as e:
                     raise ValueError(f"• Relative date parsing: {e}.")
             reminder_text = parse_result["text"] or None if "text" in parse_result else None
-            expires_at = expires_at.astimezone(tz=datetime.UTC)
+            expires_at = expires_at.astimezone(tz=datetime.timezone.utc)
             if repeat_dict is not None:
                 try:
                     repeat = cog.Repeat.from_json(
@@ -317,7 +317,7 @@ class TimeConverter(commands.Converter):
             expires_at = rrule.after(local_now.replace(tzinfo=None), inc=True)
             if expires_at is None:
                 raise ValueError("• Recurrent parsing: Impossible to parse this RRULE.")
-            expires_at = expires_at.astimezone(tz=datetime.UTC)
+            expires_at = expires_at.astimezone(tz=datetime.timezone.utc)
             # if expires_at <= utc_now.replace(minute=utc_now.minute + 1):
             #     expires_at += dateutil.relativedelta.relativedelta(minutes=2)
             try:
@@ -459,7 +459,7 @@ class TimeConverter(commands.Converter):
             #     parsed_date = parsed_date.replace(tzinfo=tz)
             #     parsed_date = parsed_date.replace(hour=9)
             # parsed_date = parsed_date.replace(tzinfo=tz)
-            parsed_date = parsed_date.astimezone(tz=datetime.UTC)
+            parsed_date = parsed_date.astimezone(tz=datetime.timezone.utc)
             return (
                 parsed_date,
                 (reminder_text or "").strip() if return_text else text,

--- a/reminders/reminders.py
+++ b/reminders/reminders.py
@@ -223,7 +223,7 @@ class Reminders(DashboardIntegration, Cog):
 
     async def reminders_loop(self, utc_now: datetime.datetime = None) -> bool:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         executed = False
         cache = {user_id: reminders.copy() for user_id, reminders in self.cache.copy().items()}
         for reminders in cache.values():
@@ -253,7 +253,7 @@ class Reminders(DashboardIntegration, Cog):
         if jump_url is None:
             jump_url = "https://discord.com/channels/0/0/0"
         if created_at is None:
-            created_at = datetime.datetime.now(tz=datetime.UTC)
+            created_at = datetime.datetime.now(tz=datetime.timezone.utc)
         reminder_id = 1
         while reminder_id in self.cache.get(user_id, {}):
             reminder_id += 1
@@ -1344,7 +1344,7 @@ class Reminders(DashboardIntegration, Cog):
             await self.config.maximum_user_reminders(),
         )
         await self.config.set(new_global_data)
-        utc_now_timestamp = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        utc_now_timestamp = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         old_config.init_custom("REMINDER", 2)
         old_reminders_data = await old_config.custom("REMINDER").all()
         for user_id in old_reminders_data:
@@ -1368,16 +1368,16 @@ class Reminders(DashboardIntegration, Cog):
                         targets=None,
                         created_at=datetime.datetime.fromtimestamp(
                             reminder_data["created"],
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         ),
                         expires_at=datetime.datetime.fromtimestamp(
                             reminder_data["expires"],
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         ),
                         last_expires_at=None,
                         next_expires_at=datetime.datetime.fromtimestamp(
                             reminder_data["expires"],
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         ),
                         repeat=(
                             Repeat.from_json(
@@ -1407,7 +1407,7 @@ class Reminders(DashboardIntegration, Cog):
             force_registration=True,
             cog_name="FIFO",
         )
-        utc_now = datetime.datetime.now(tz=datetime.UTC)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         old_guilds_data = await old_config.all_guilds()
         for guild_id in old_guilds_data:
             reminder_id = 1
@@ -1435,7 +1435,7 @@ class Reminders(DashboardIntegration, Cog):
                                     "type": "date",
                                     "value": int(
                                         dateutil.parser.isoparse(trigger["time_data"])
-                                        .replace(tzinfo=datetime.UTC)
+                                        .replace(tzinfo=datetime.timezone.utc)
                                         .timestamp(),
                                     ),
                                     "start_trigger": None,

--- a/reminders/types.py
+++ b/reminders/types.py
@@ -95,19 +95,19 @@ class RepeatRule:
         if data["type"] == "date":
             return cls(
                 type=data["type"],
-                value=datetime.datetime.fromtimestamp(int(data["value"]), tz=datetime.UTC),
+                value=datetime.datetime.fromtimestamp(int(data["value"]), tz=datetime.timezone.utc),
                 start_trigger=(
-                    datetime.datetime.fromtimestamp(data["start_trigger"], tz=datetime.UTC)
+                    datetime.datetime.fromtimestamp(data["start_trigger"], tz=datetime.timezone.utc)
                     if data.get("start_trigger") is not None
                     else None
                 ),
                 first_trigger=(
-                    datetime.datetime.fromtimestamp(data["first_trigger"], tz=datetime.UTC)
+                    datetime.datetime.fromtimestamp(data["first_trigger"], tz=datetime.timezone.utc)
                     if data.get("first_trigger") is not None
                     else None
                 ),
                 last_trigger=(
-                    datetime.datetime.fromtimestamp(data["last_trigger"], tz=datetime.UTC)
+                    datetime.datetime.fromtimestamp(data["last_trigger"], tz=datetime.timezone.utc)
                     if data.get("last_trigger") is not None
                     else None
                 ),
@@ -116,17 +116,17 @@ class RepeatRule:
             type=data["type"],
             value=data["value"],
             start_trigger=(
-                datetime.datetime.fromtimestamp(data["start_trigger"], tz=datetime.UTC)
+                datetime.datetime.fromtimestamp(data["start_trigger"], tz=datetime.timezone.utc)
                 if data.get("start_trigger") is not None
                 else None
             ),
             first_trigger=(
-                datetime.datetime.fromtimestamp(data["first_trigger"], tz=datetime.UTC)
+                datetime.datetime.fromtimestamp(data["first_trigger"], tz=datetime.timezone.utc)
                 if data.get("first_trigger") is not None
                 else None
             ),
             last_trigger=(
-                datetime.datetime.fromtimestamp(data["last_trigger"], tz=datetime.UTC)
+                datetime.datetime.fromtimestamp(data["last_trigger"], tz=datetime.timezone.utc)
                 if data.get("last_trigger") is not None
                 else None
             ),
@@ -135,15 +135,15 @@ class RepeatRule:
     @executor()
     def next_trigger(
         self,
-        last_expires_at: datetime.datetime = datetime.datetime.now(tz=datetime.UTC),
-        utc_now: datetime.datetime = datetime.datetime.now(tz=datetime.UTC),
+        last_expires_at: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc),
+        utc_now: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc),
         timezone: str = "UTC",
     ) -> datetime.datetime | None:
         self.last_trigger = self.last_trigger or last_expires_at
         if self.last_trigger > last_expires_at and self.last_trigger >= utc_now:
             return self.last_trigger
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         if self.type == "sample":
             repeat_delta = dateutil.relativedelta.relativedelta(**self.value)
             next_expires_at = last_expires_at + repeat_delta
@@ -162,7 +162,7 @@ class RepeatRule:
                 )
                 if next_expires_at is None:
                     return None
-                next_expires_at = next_expires_at.astimezone(tz=datetime.UTC)
+                next_expires_at = next_expires_at.astimezone(tz=datetime.timezone.utc)
         elif self.type == "rrule":
             tz = pytz.timezone(timezone)
             rrule = dateutil.rrule.rrulestr(
@@ -179,7 +179,7 @@ class RepeatRule:
             if next_expires_at is None:
                 return None
             next_expires_at = next_expires_at.astimezone(
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             )  # `astimezone` is not required
         elif self.type == "date":
             return self.value
@@ -238,12 +238,12 @@ class Repeat:
 
     async def next_trigger(
         self,
-        last_expires_at: datetime.datetime = datetime.datetime.now(tz=datetime.UTC),
+        last_expires_at: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc),
         utc_now: datetime.datetime = None,
         timezone: str = "UTC",
     ) -> datetime.datetime | None:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         next_triggers = [
             await rule.next_trigger(
                 last_expires_at=last_expires_at,
@@ -297,28 +297,28 @@ class Reminder:
         )
 
     def __eq__(self, other: "Reminder") -> bool:
-        return (self.next_expires_at or datetime.datetime.now(tz=datetime.UTC)) == (
-            other.next_expires_at or datetime.datetime.now(tz=datetime.UTC)
+        return (self.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)) == (
+            other.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)
         )
 
     def __lt__(self, other: "Reminder") -> bool:
-        return (self.next_expires_at or datetime.datetime.now(tz=datetime.UTC)) < (
-            other.next_expires_at or datetime.datetime.now(tz=datetime.UTC)
+        return (self.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)) < (
+            other.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)
         )
 
     def __le__(self, other: "Reminder") -> bool:
-        return (self.next_expires_at or datetime.datetime.now(tz=datetime.UTC)) <= (
-            other.next_expires_at or datetime.datetime.now(tz=datetime.UTC)
+        return (self.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)) <= (
+            other.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)
         )
 
     def __gt__(self, other: "Reminder") -> bool:
-        return (self.next_expires_at or datetime.datetime.now(tz=datetime.UTC)) > (
-            other.next_expires_at or datetime.datetime.now(tz=datetime.UTC)
+        return (self.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)) > (
+            other.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)
         )
 
     def __ge__(self, other: "Reminder") -> bool:
-        return (self.next_expires_at or datetime.datetime.now(tz=datetime.UTC)) >= (
-            other.next_expires_at or datetime.datetime.now(tz=datetime.UTC)
+        return (self.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)) >= (
+            other.next_expires_at or datetime.datetime.now(tz=datetime.timezone.utc)
         )
 
     def to_json(self, clean: bool = True) -> Data:
@@ -367,23 +367,23 @@ class Reminder:
             ),
             created_at=datetime.datetime.fromtimestamp(
                 int(data["created_at"]),
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             ),
             expires_at=datetime.datetime.fromtimestamp(
                 int(data["expires_at"]),
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             ),
             last_expires_at=(
                 datetime.datetime.fromtimestamp(
                     int(data["last_expires_at"]),
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 )
                 if data.get("last_expires_at") is not None
                 else None
             ),
             next_expires_at=datetime.datetime.fromtimestamp(
                 int(data["next_expires_at"]),
-                tz=datetime.UTC,
+                tz=datetime.timezone.utc,
             ),
             repeat=(
                 Repeat.from_json(data.get("repeat") or data.get("intervals"))
@@ -394,7 +394,7 @@ class Reminder:
 
     def __str__(self, utc_now: datetime.datetime = None) -> str:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         and_every = ""
         if self.repeat is not None:
             if len(self.repeat.rules) == 1:
@@ -587,7 +587,7 @@ class Reminder:
         embed_color: discord.Color = discord.Color.green(),
     ) -> discord.Embed:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         delayed = int(
             utc_now.timestamp() - (self.last_expires_at or self.next_expires_at).timestamp(),
         )
@@ -666,7 +666,7 @@ class Reminder:
         testing: bool = False,
     ) -> None:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         if not testing:
             self.last_expires_at = self.next_expires_at
             timezone = (await self.cog.config.user_from_id(self.user_id).timezone()) or "UTC"

--- a/reminders/views.py
+++ b/reminders/views.py
@@ -273,7 +273,7 @@ class ReminderView(discord.ui.View):
         reminder_id = 1
         while reminder_id in self.cog.cache.get(interaction.user.id, {}):
             reminder_id += 1
-        utc_now = datetime.datetime.now(tz=datetime.UTC)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         reminder = self.cog.Reminder(
             cog=self.cog,
             user_id=interaction.user.id,
@@ -631,7 +631,7 @@ class SnoozeView(discord.ui.View):
         reminder_id = 1
         while reminder_id in self.cog.cache.get(self.reminder.user_id, {}):
             reminder_id += 1
-        utc_now = datetime.datetime.now(tz=datetime.UTC)
+        utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         expires_at = utc_now + timedelta
         reminder = self.cog.Reminder(
             cog=self.cog,

--- a/rolloutgame/views.py
+++ b/rolloutgame/views.py
@@ -223,7 +223,7 @@ class RolloutGameView(discord.ui.View):
         self._number = choice([i for i in range(1, 25 + 1) if i not in self.disabled_numbers])
         embed.add_field(
             name="Time Left:",
-            value=f"<t:{int((datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=30)).timestamp())}:R>",
+            value=f"<t:{int((datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=30)).timestamp())}:R>",
         )
         self._message: discord.Message = await ctx.send(
             content=humanize_list([player.mention for player in self.players]),

--- a/runcode/types.py
+++ b/runcode/types.py
@@ -176,7 +176,7 @@ class WandboxResponse:
             title=_("RunCode Response (with Wandbox API)"),
             url=self.url,
         )
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         run_time = format_timespan(self.run_time)
         embed.set_footer(text=f"Ran in {run_time}.")
         embed.set_author(
@@ -340,7 +340,7 @@ class TioResponse:
             title=_("RunCode Response (with Tio API)"),
             url=self.request.language.link,
         )
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         run_time = format_timespan(self.run_time)
         embed.set_footer(text=f"Ran in {run_time}.")
         embed.set_author(name=f"{self.request.language.name.capitalize()} language")

--- a/security/constants.py
+++ b/security/constants.py
@@ -441,7 +441,7 @@ def get_correct_timeout_duration(
     duration: datetime.timedelta,
 ) -> datetime.timedelta:
     if member.is_timed_out():
-        duration += member.timed_out_until - datetime.datetime.now(datetime.UTC)
+        duration += member.timed_out_until - datetime.datetime.now(datetime.timezone.utc)
     return min(duration, datetime.timedelta(days=28))
 
 

--- a/security/modules/auto_mod.py
+++ b/security/modules/auto_mod.py
@@ -734,7 +734,8 @@ class AutoModModule(Module):
         if heats:
             degradation = await self.config_value(guild).heats.degradation()
             to_remove = (
-                degradation * (datetime.datetime.now(tz=datetime.UTC) - heats[0][0]).total_seconds()
+                degradation
+                * (datetime.datetime.now(tz=datetime.timezone.utc) - heats[0][0]).total_seconds()
             )
             while to_remove > 0 and heats:
                 if heats[0][2] <= to_remove:
@@ -909,7 +910,7 @@ class AutoModModule(Module):
                         guild=message.guild,
                         author=message.guild.me,
                         user=message.author,
-                        until=datetime.datetime.now(tz=datetime.UTC) + duration,
+                        until=datetime.datetime.now(tz=datetime.timezone.utc) + duration,
                         reason=audit_log_reason,
                     )
                 elif action == "kick" and message.guild.me.guild_permissions.kick_members:

--- a/security/modules/dank_pool_protection.py
+++ b/security/modules/dank_pool_protection.py
@@ -176,7 +176,7 @@ class Payout:
 
     @property
     def issued_at(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self.issued_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.issued_at_timestamp, tz=datetime.timezone.utc)
 
     @property
     def display_amount(self) -> str:
@@ -624,7 +624,7 @@ class DankPoolProtectionModule(Module):
             (
                 datetime.datetime.fromtimestamp(
                     last_payout["issued_at_timestamp"],
-                    tz=datetime.UTC,
+                    tz=datetime.timezone.utc,
                 ),
                 _(
                     "{member.mention} (`{member}`) executed `{slash_name}` ({jump_url}) {timestamp}.",

--- a/security/modules/join_gate.py
+++ b/security/modules/join_gate.py
@@ -70,7 +70,8 @@ JOIN_GATE_OPTIONS: list[
         "param": ("minimum_days", int, 7),
         "value": "account_age",
         "check": lambda member, minimum_days: (
-            (datetime.datetime.now(tz=datetime.UTC) - member.created_at).days < minimum_days
+            (datetime.datetime.now(tz=datetime.timezone.utc) - member.created_at).days
+            < minimum_days
         ),
     },
     {
@@ -346,7 +347,9 @@ class JoinGateModule(Module):
                 _("\n- Account Age: {account_age}\n- Minimum Age: {minimum_days} days").format(
                     account_age=CogsUtils.get_interval_string(
                         datetime.timedelta(
-                            days=(datetime.datetime.now(tz=datetime.UTC) - member.created_at).days,
+                            days=(
+                                datetime.datetime.now(tz=datetime.timezone.utc) - member.created_at
+                            ).days,
                         ),
                     ),
                     minimum_days=option_config["minimum_days"],
@@ -376,7 +379,7 @@ class JoinGateModule(Module):
                     guild=member.guild,
                     author=member.guild.me,
                     user=member,
-                    until=datetime.datetime.now(tz=datetime.UTC) + duration,
+                    until=datetime.datetime.now(tz=datetime.timezone.utc) + duration,
                     reason=audit_log_reason,
                 )
             elif action == "kick" and member.guild.me.guild_permissions.kick_members:

--- a/security/modules/logging.py
+++ b/security/modules/logging.py
@@ -974,7 +974,9 @@ class LoggingModule(Module):
             title=f"{event['name']} {event['emoji']}",
             color=discord.Color(event["color"]),
             timestamp=(
-                entry.created_at if entry is not None else datetime.datetime.now(datetime.UTC)
+                entry.created_at
+                if entry is not None
+                else datetime.datetime.now(datetime.timezone.utc)
             ),
         )
 

--- a/security/modules/reports.py
+++ b/security/modules/reports.py
@@ -264,7 +264,7 @@ class ReasonModal(discord.ui.Modal):
                 emoji=self.module.emoji,
             ),
             color=Colors.REPORTS.value,
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.description = _("👤 **Member:** {member.mention} (`{member}`) {member_emoji}").format(
             member=member,

--- a/security/modules/sentinel_relay.py
+++ b/security/modules/sentinel_relay.py
@@ -194,7 +194,7 @@ class SentinelRelayModule(Module):
                             "The main bot ({mention}) is offline, triggering the relay.",
                         ).format(mention=main_bot.mention),
                         color=discord.Color.red(),
-                        timestamp=datetime.datetime.now(tz=datetime.UTC),
+                        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                     )
                     embed.set_author(name=main_bot.display_name, icon_url=main_bot.display_avatar)
                     embed.add_field(
@@ -221,7 +221,7 @@ class SentinelRelayModule(Module):
                             "The main bot ({mention}) is back online, untriggering the relay.",
                         ).format(mention=main_bot.mention),
                         color=discord.Color.green(),
-                        timestamp=datetime.datetime.now(tz=datetime.UTC),
+                        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                     )
                     embed.set_author(name=main_bot.display_name, icon_url=main_bot.display_avatar)
                     embed.add_field(

--- a/security/security.py
+++ b/security/security.py
@@ -237,7 +237,7 @@ class Security(Cog):
         if member.guild_permissions.manage_messages or await self.bot.is_mod(member):
             return Levels.MODERATOR
         if datetime.datetime.now(
-            tz=datetime.UTC,
+            tz=datetime.timezone.utc,
         ) - member.joined_at >= datetime.timedelta(days=7):
             return Levels.MEMBER
         return Levels.NEW
@@ -391,7 +391,7 @@ class Security(Cog):
                         prefix=(await self.bot.get_valid_prefixes(guild))[-1],
                     ),
                     color=discord.Color.red(),
-                    timestamp=datetime.datetime.now(tz=datetime.UTC),
+                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                 )
                 embed.set_author(
                     name=guild.owner.name,
@@ -673,7 +673,7 @@ class Security(Cog):
                 ),
             }[action],
             color=getattr(Colors, action.upper().removeprefix("UN")).value,
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_thumbnail(url=member.display_avatar)
         embed.set_footer(text=member.guild.name, icon_url=get_non_animated_asset(member.guild.icon))
@@ -802,7 +802,7 @@ class Security(Cog):
         await modlog.create_case(
             bot=self.bot,
             guild=member.guild,
-            created_at=datetime.datetime.now(tz=datetime.UTC),
+            created_at=datetime.datetime.now(tz=datetime.timezone.utc),
             action_type=action
             if action not in ("mute", "unmute")
             else f"s{action}",  # server mute/unmute
@@ -1121,7 +1121,7 @@ class Security(Cog):
                 "**The Security system can't function properly without me! If you're not responsible for this, you must check what is happening in your server IMMEDIATELY!**",
             ),
             color=discord.Color.red(),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_thumbnail(url=get_non_animated_asset(guild.icon))
         embed.set_footer(
@@ -1352,7 +1352,7 @@ class Security(Cog):
         embed: discord.Embed = discord.Embed(
             title=_("Last Payouts ({number})").format(number=len(payouts)),
             color=Colors.DANK_POOL_PROTECTION.value,
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
 
         async def format_member_user(

--- a/security/views.py
+++ b/security/views.py
@@ -221,7 +221,7 @@ class WhitelistView(discord.ui.View):
         embed = self._message.embeds[0]
         if self.saved:
             if self.duration is not None:
-                expires_at = datetime.datetime.now(tz=datetime.UTC) + self.duration
+                expires_at = datetime.datetime.now(tz=datetime.timezone.utc) + self.duration
                 embed.description += _("\n⏲️ **Expiration:** {F_timestamp} ({R_timestamp})").format(
                     F_timestamp=discord.utils.format_dt(expires_at, style="F"),
                     R_timestamp=discord.utils.format_dt(expires_at, style="R"),
@@ -1098,7 +1098,7 @@ class ActionsView(discord.ui.View):
                 guild=self.member.guild,
                 author=interaction.user,
                 user=self.member,
-                until=datetime.datetime.now(tz=datetime.UTC) + duration,
+                until=datetime.datetime.now(tz=datetime.timezone.utc) + duration,
                 reason=reason,
             )
         elif action == "unmute":

--- a/seen/seen.py
+++ b/seen/seen.py
@@ -320,7 +320,7 @@ class Seen(Cog):
         reaction: str | None = None,
     ) -> None:
         if time is None:
-            time = datetime.datetime.now(tz=datetime.UTC)
+            time = datetime.datetime.now(tz=datetime.timezone.utc)
         if not isinstance(channel, discord.TextChannel):
             return
         custom_id = CogsUtils.generate_key(
@@ -625,7 +625,7 @@ class Seen(Cog):
         if not await self.config.listeners.message():
             return
         self.upsert_cache(
-            time=datetime.datetime.now(tz=datetime.UTC),
+            time=datetime.datetime.now(tz=datetime.timezone.utc),
             _type="message",
             member=message.author,
             guild=message.guild,
@@ -667,7 +667,7 @@ class Seen(Cog):
         if not await self.config.listeners.message_edit():
             return
         self.upsert_cache(
-            time=datetime.datetime.now(tz=datetime.UTC),
+            time=datetime.datetime.now(tz=datetime.timezone.utc),
             _type="message_edit",
             member=after.author,
             guild=after.guild,
@@ -705,7 +705,7 @@ class Seen(Cog):
         if not await self.config.listeners.reaction_add():
             return
         self.upsert_cache(
-            time=datetime.datetime.now(tz=datetime.UTC),
+            time=datetime.datetime.now(tz=datetime.timezone.utc),
             _type="reaction_add",
             member=user,
             guild=user.guild,
@@ -735,7 +735,7 @@ class Seen(Cog):
         if not await self.config.listeners.reaction_remove():
             return
         self.upsert_cache(
-            time=datetime.datetime.now(tz=datetime.UTC),
+            time=datetime.datetime.now(tz=datetime.timezone.utc),
             _type="reaction_remove",
             member=user,
             guild=user.guild,
@@ -867,7 +867,7 @@ class Seen(Cog):
             _type = data["_type"]
             del data["_type"]
         time = data["seen"]
-        now = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        now = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         time_elapsed = int(now - time)
         m, s = divmod(time_elapsed, 60)
         h, m = divmod(m, 60)

--- a/serversupporters/serversupporters.py
+++ b/serversupporters/serversupporters.py
@@ -160,7 +160,7 @@ class ServerSupporters(Cog):
                 else _("Server {_type} Supporter Removed...")
             ).format(_type=_("Tag") if _type == "tag" else _("Status")),
             color=discord.Color.green() if enabled else discord.Color.red(),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_author(
             name=member.display_name,

--- a/snipe/snipe.py
+++ b/snipe/snipe.py
@@ -57,7 +57,7 @@ class SnipedMessage:
         )
 
         self.created_at: datetime.datetime = message.created_at
-        self.deleted_at: datetime.datetime = datetime.datetime.now(tz=datetime.UTC)
+        self.deleted_at: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc)
 
         if message.reference is not None and isinstance(
             (reference := message.reference.resolved),
@@ -571,7 +571,7 @@ class Snipe(DashboardIntegration, Cog):
             title=_("Deleted Messages"),
             color=await ctx.embed_color(),
         )
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         embed.set_footer(text=f"#{channel.name}", icon_url=channel.guild.icon)
         embeds = []
         for page in pagify(content, delims=("\n\n",)):
@@ -887,7 +887,7 @@ class Snipe(DashboardIntegration, Cog):
             title=_("Edited Messages"),
             color=await ctx.embed_color(),
         )
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         embed.set_footer(text=f"#{channel.name}", icon_url=channel.guild.icon)
         embeds = []
         for page in pagify(content, delims=("\n\n",)):

--- a/teams/types.py
+++ b/teams/types.py
@@ -41,7 +41,9 @@ class Point:
     managed_by_id: int | None = None
     managed_at_timestamp: int = field(
         default_factory=lambda: int(
-            datetime.datetime.now(tz=datetime.UTC).replace(second=0, microsecond=0).timestamp(),
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .replace(second=0, microsecond=0)
+            .timestamp(),
         ),
     )
 
@@ -60,7 +62,7 @@ class Point:
 
     @property
     def managed_at(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self.managed_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.managed_at_timestamp, tz=datetime.timezone.utc)
 
 
 @dataclass
@@ -84,7 +86,9 @@ class Team:
     image_url: str | None = None
     created_at_timestamp: int = field(
         default_factory=lambda: int(
-            datetime.datetime.now(tz=datetime.UTC).replace(second=0, microsecond=0).timestamp(),
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .replace(second=0, microsecond=0)
+            .timestamp(),
         ),
     )
 
@@ -188,7 +192,7 @@ class Team:
 
     @property
     def created_at(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self.created_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.created_at_timestamp, tz=datetime.timezone.utc)
 
     @created_at.setter
     def created_at(self, created_at: datetime.datetime) -> None:
@@ -267,7 +271,7 @@ class Team:
         embed: discord.Embed = discord.Embed(
             title=self.display_name,
             color=self.color or await self.bot.get_embed_color(self.guild.text_channels[0]),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.set_thumbnail(url=self.display_logo_url)
         if not sample:

--- a/temproles/temproles.py
+++ b/temproles/temproles.py
@@ -116,7 +116,7 @@ class TempRoles(Cog):
 
     async def temp_roles_loop(self, utc_now: datetime.datetime = None) -> bool:
         if utc_now is None:
-            utc_now = datetime.datetime.now(tz=datetime.UTC)
+            utc_now = datetime.datetime.now(tz=datetime.timezone.utc)
         executed = False
         member_group = self.config._get_base_group(self.config.MEMBER)
         async with member_group.all() as members_data:
@@ -133,7 +133,7 @@ class TempRoles(Cog):
                     ].items():
                         if datetime.datetime.fromtimestamp(
                             expires_times,
-                            tz=datetime.UTC,
+                            tz=datetime.timezone.utc,
                         ) <= utc_now.replace(microsecond=0):
                             executed = True
                             if (temp_role := guild.get_role(int(temp_role_id))) is not None:
@@ -188,7 +188,7 @@ class TempRoles(Cog):
         }
         for role, duration in joining_temp_roles.items():
             try:
-                end_time = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
+                end_time = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
                     seconds=duration,
                 )
             except OverflowError:
@@ -207,7 +207,7 @@ class TempRoles(Cog):
                 )
             else:
                 member_temp_roles = await self.config.member(member).temp_roles()
-                end_time = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
+                end_time = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
                     seconds=duration,
                 )
                 member_temp_roles[str(role.id)] = int(end_time.replace(microsecond=0).timestamp())
@@ -246,13 +246,13 @@ class TempRoles(Cog):
                     auto_temp_roles = await self.config.guild(after.guild).auto_temp_roles()
                     duration = datetime.timedelta(seconds=auto_temp_roles[str(role.id)])
                     try:
-                        end_time = datetime.datetime.now(tz=datetime.UTC) + duration
+                        end_time = datetime.datetime.now(tz=datetime.timezone.utc) + duration
                     except OverflowError:
                         continue
                     end_time = end_time.replace(second=0 if end_time.second < 30 else 30)
                     duration_string = CogsUtils.get_interval_string(duration)
                     member_temp_roles = await self.config.member(after).temp_roles()
-                    end_time = datetime.datetime.now(tz=datetime.UTC) + duration
+                    end_time = datetime.datetime.now(tz=datetime.timezone.utc) + duration
                     member_temp_roles[str(role.id)] = int(
                         end_time.replace(microsecond=0).timestamp(),
                     )
@@ -326,7 +326,7 @@ class TempRoles(Cog):
                 _("You can't assign this role to this member, due to the Discord role hierarchy."),
             )
         try:
-            end_time: datetime.datetime = datetime.datetime.now(tz=datetime.UTC) + duration
+            end_time: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc) + duration
         except OverflowError:
             raise commands.UserFeedbackCheckFailure(
                 _("The time set is way too high, consider setting something reasonable."),
@@ -389,7 +389,7 @@ class TempRoles(Cog):
         if str(role.id) not in member_temp_roles:
             raise commands.UserFeedbackCheckFailure(_("This role isn't a TempRole of this member."))
         try:
-            end_time: datetime.datetime = datetime.datetime.now(tz=datetime.UTC) + duration
+            end_time: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc) + duration
         except OverflowError:
             raise commands.UserFeedbackCheckFailure(
                 _("The time set is way too high, consider setting something reasonable."),

--- a/tickets/tickets.py
+++ b/tickets/tickets.py
@@ -495,7 +495,7 @@ class Tickets(DashboardIntegration, Cog):
                 if (
                     ticket.is_closed
                     and config["auto_delete_on_close"] is not None
-                    and datetime.datetime.now(tz=datetime.UTC) - ticket.closed_at
+                    and datetime.datetime.now(tz=datetime.timezone.utc) - ticket.closed_at
                     > datetime.timedelta(hours=config["auto_delete_on_close"])
                 ):
                     await ticket.delete_channel(None)  # That's a setting, so no deleter.

--- a/tickets/types.py
+++ b/tickets/types.py
@@ -72,7 +72,9 @@ class Ticket:
 
     opened_at_timestamp: int = field(
         default_factory=lambda: int(
-            datetime.datetime.now(tz=datetime.UTC).replace(second=0, microsecond=0).timestamp(),
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .replace(second=0, microsecond=0)
+            .timestamp(),
         ),
     )
     is_claimed: bool = False
@@ -165,7 +167,7 @@ class Ticket:
 
     @property
     def opened_at(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self.opened_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.opened_at_timestamp, tz=datetime.timezone.utc)
 
     @opened_at.setter
     def opened_at(self, opened_at: datetime.datetime) -> None:
@@ -188,7 +190,7 @@ class Ticket:
     def claimed_at(self) -> datetime.datetime | None:
         if self.claimed_at_timestamp is None:
             return None
-        return datetime.datetime.fromtimestamp(self.claimed_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.claimed_at_timestamp, tz=datetime.timezone.utc)
 
     @claimed_at.setter
     def claimed_at(self, claimed_at: datetime.datetime | None) -> None:
@@ -211,7 +213,7 @@ class Ticket:
     def closed_at(self) -> datetime.datetime | None:
         if self.closed_at_timestamp is None:
             return None
-        return datetime.datetime.fromtimestamp(self.closed_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.closed_at_timestamp, tz=datetime.timezone.utc)
 
     @closed_at.setter
     def closed_at(self, closed_at: datetime.datetime | None) -> None:
@@ -247,7 +249,7 @@ class Ticket:
     def locked_at(self) -> datetime.datetime | None:
         if self.locked_at_timestamp is None:
             return None
-        return datetime.datetime.fromtimestamp(self.locked_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.locked_at_timestamp, tz=datetime.timezone.utc)
 
     @locked_at.setter
     def locked_at(self, locked_at: datetime.datetime | None) -> None:
@@ -270,7 +272,7 @@ class Ticket:
     def unlocked_at(self) -> datetime.datetime | None:
         if self.unlocked_at_timestamp is None:
             return None
-        return datetime.datetime.fromtimestamp(self.unlocked_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.unlocked_at_timestamp, tz=datetime.timezone.utc)
 
     @unlocked_at.setter
     def unlocked_at(self, unlocked_at: datetime.datetime | None) -> None:
@@ -295,7 +297,7 @@ class Ticket:
             return None
         return datetime.datetime.fromtimestamp(
             self.appeal_approved_at_timestamp,
-            tz=datetime.UTC,
+            tz=datetime.timezone.utc,
         )
 
     @appeal_approved_at.setter
@@ -321,7 +323,7 @@ class Ticket:
     def deleted_at(self) -> datetime.datetime | None:
         if self.deleted_at_timestamp is None:
             return None
-        return datetime.datetime.fromtimestamp(self.deleted_at_timestamp, tz=datetime.UTC)
+        return datetime.datetime.fromtimestamp(self.deleted_at_timestamp, tz=datetime.timezone.utc)
 
     @deleted_at.setter
     def deleted_at(self, deleted_at: datetime.datetime | None) -> None:
@@ -848,7 +850,7 @@ class Ticket:
         # self.reopened_by = None
         # self.reopened_at = None
         self.closed_by = closer
-        self.closed_at = datetime.datetime.now(tz=datetime.UTC)
+        self.closed_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         await self.log_action(
@@ -943,7 +945,7 @@ class Ticket:
         # self.closed_by = None
         # self.closed_at = None
         self.reopened_by = reopener
-        self.reopened_at = datetime.datetime.now(tz=datetime.UTC)
+        self.reopened_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         if reopener is None:
@@ -1004,7 +1006,7 @@ class Ticket:
             raise RuntimeError(_("This ticket is already claimed."))
         self.is_claimed = True
         self.claimed_by = claimer
-        self.claimed_at = datetime.datetime.now(tz=datetime.UTC)
+        self.claimed_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         audit_reason = _(
@@ -1068,7 +1070,7 @@ class Ticket:
             await modlog.create_case(
                 bot=self.bot,
                 guild=self.guild,
-                created_at=datetime.datetime.now(tz=datetime.UTC),
+                created_at=datetime.datetime.now(tz=datetime.timezone.utc),
                 action_type="ticket_unclaimed",
                 user=self.owner or self.owner_id,
                 moderator=self.guild.me,
@@ -1096,7 +1098,7 @@ class Ticket:
                 raise RuntimeError(_("You aren't allowed to lock this ticket!"))
         self.is_locked = True
         self.locked_by = locker
-        self.locked_at = datetime.datetime.now(tz=datetime.UTC)
+        self.locked_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         if locker is None:
@@ -1167,7 +1169,7 @@ class Ticket:
         # self.locked_by = None
         # self.locked_at = None
         self.unlocked_by = unlocker
-        self.unlocked_at = datetime.datetime.now(tz=datetime.UTC)
+        self.unlocked_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         if unlocker is not None:
@@ -1230,7 +1232,7 @@ class Ticket:
             )
         self.appeal_approved = True
         self.appeal_approved_by = approver
-        self.appeal_approved_at = datetime.datetime.now(tz=datetime.UTC)
+        self.appeal_approved_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
 
         if approver is None:
@@ -1294,7 +1296,7 @@ class Ticket:
             await modlog.create_case(
                 bot=self.bot,
                 guild=self.guild,
-                created_at=datetime.datetime.now(tz=datetime.UTC),
+                created_at=datetime.datetime.now(tz=datetime.timezone.utc),
                 action_type="ticket_appeal_approved",
                 user=self.owner or self.owner_id,
                 moderator=self.guild.me,
@@ -1366,7 +1368,7 @@ class Ticket:
             await modlog.create_case(
                 bot=self.bot,
                 guild=self.guild,
-                created_at=datetime.datetime.now(tz=datetime.UTC),
+                created_at=datetime.datetime.now(tz=datetime.timezone.utc),
                 action_type="ticket_member_added",
                 user=member,
                 moderator=author,
@@ -1426,7 +1428,7 @@ class Ticket:
             await modlog.create_case(
                 bot=self.bot,
                 guild=self.guild,
-                created_at=datetime.datetime.now(tz=datetime.UTC),
+                created_at=datetime.datetime.now(tz=datetime.timezone.utc),
                 action_type="ticket_member_removed",
                 user=member,
                 moderator=author,
@@ -1446,7 +1448,7 @@ class Ticket:
                 + (_(" by {author.mention}").format(author=author) if author is not None else ""),
             ),
             color=await self.bot.get_embed_color(self.channel),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         if target is not None:
             embed.add_field(
@@ -1519,7 +1521,7 @@ class Ticket:
 
     async def delete_channel(self, deleter: discord.Member | None = None) -> None:
         self.deleted_by = deleter
-        self.deleted_at = datetime.datetime.now(tz=datetime.UTC)
+        self.deleted_at = datetime.datetime.now(tz=datetime.timezone.utc)
         await self.save()
         if deleter is None:
             audit_reason = _("Ticket deleted (profile `{self.profile}`).").format(self=self)
@@ -1543,7 +1545,7 @@ class Ticket:
                             self=self,
                         ),
                         color=discord.Color.red(),
-                        timestamp=datetime.datetime.now(tz=datetime.UTC),
+                        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                     ),
                     await self.get_embed(for_logging=True),
                 ],
@@ -1560,7 +1562,7 @@ class Ticket:
             await modlog.create_case(
                 bot=self.bot,
                 guild=self.guild,
-                created_at=datetime.datetime.now(tz=datetime.UTC),
+                created_at=datetime.datetime.now(tz=datetime.timezone.utc),
                 action_type="ticket_deleted",
                 user=self.owner or self.owner_id,
                 moderator=deleter,

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -298,7 +298,7 @@ class MembersView(discord.ui.View):
                 s="s" if len(self.ticket.members_ids) != 1 else "",
             ),
             color=await self.cog.bot.get_embed_color(self.ticket.channel),
-            timestamp=datetime.datetime.now(tz=datetime.UTC),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.description = "\n".join(
             _("**{i}.** {member.mention} ({member.id})").format(i=i, member=member)

--- a/tickettool/tickettool.py
+++ b/tickettool/tickettool.py
@@ -540,7 +540,7 @@ class TicketTool(settings, DashboardIntegration, Cog):
         embed.description = f"{description}"
         embed.set_thumbnail(url=actual_thumbnail)
         embed.color = actual_color
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         embed.set_author(
             name=author,
             url=author.display_avatar,
@@ -617,7 +617,7 @@ class TicketTool(settings, DashboardIntegration, Cog):
         )
         embed.description = f"{action}"
         embed.color = actual_color
-        embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+        embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         embed.set_author(
             name=author,
             url=author.display_avatar,

--- a/viewpermissions/viewpermissions.py
+++ b/viewpermissions/viewpermissions.py
@@ -199,7 +199,7 @@ class ViewPermissions(Cog):
                 color=embed_color,
             )
             embed.set_author(name=guild.name, icon_url=guild.icon)
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             description = ""
             if roles:
                 description += _("\n**Role(s):** {roles}").format(
@@ -249,7 +249,7 @@ class ViewPermissions(Cog):
         else:
             embed: discord.Embed = discord.Embed(title=_("View Permissions"), color=embed_color)
             embed.set_author(name=guild.name, icon_url=guild.icon)
-            embed.timestamp = datetime.datetime.now(tz=datetime.UTC)
+            embed.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
             description = ""
             if roles:
                 description += _("\n**Role(s):** {roles}").format(


### PR DESCRIPTION
This PR is fully search replacing `datetime.UTC` (added in python 3.11) by `datetime.timezone.utc`, however, it's just like going back to before ruff Python 3.12 mistake. Hopefully, this should fix errors such as the following :
<img width="852" height="593" alt="image" src="https://github.com/user-attachments/assets/62a5fe04-8a1d-4dfb-9b26-8b941faaa97d" />
(creds to epixplays.yt)
There is no other changes, so you're free to review it safely.