### PR TITLE
[Security] Fix bug in get or fetch member.

### DIFF
--- a/security/security.py
+++ b/security/security.py
@@ -1135,7 +1135,7 @@ class Security(Cog):
         for member_id, data in (await self.config.all_members(guild)).items():
             if data.get("level") is None:
                 continue
-            if (user := get_or_fetch_member_or_user(guild, member_id)) is None:
+            if (user := await get_or_fetch_member_or_user(self.bot, guild, member_id)) is None:
                 continue
             try:
                 await user.send(embed=embed)


### PR DESCRIPTION
Fixes the following TypeError:
```python
#2684 [2026-06-12 19:52:56] ERROR [discord.client] Ignoring exception in on_guild_remove.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/client.py", line 508, in _run_event
await coro(*args, **kwargs)
File "{HOME}/data/cogs/CogManager/cogs/security/security.py", line 1138, in on_guild_remove
if (user := get_or_fetch_member_or_user(guild, member_id)) is None:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: get_or_fetch_member_or_user() missing 1 required positional argument: 'user_id'
```