### PR TITLE
[PersonalReact] Fix invalid emoji error.

### DIFF
--- a/personalreact/views.py
+++ b/personalreact/views.py
@@ -452,10 +452,19 @@ class ReactionsView(discord.ui.View):
             self.remove.options = []
             for r in reactions:
                 reaction = r if isinstance(r, str) else self.ctx.bot.get_emoji(r)
+                # Strip the variation selector (U+FE0F) from plain unicode emoji strings;
+                # Discord's API rejects it in the PartialEmoji.name field (error 50035).
+                emoji_val = (
+                    reaction.rstrip("\N{VARIATION SELECTOR-16}")
+                    if isinstance(reaction, str)
+                    else reaction
+                )
                 self.remove.options.append(
                     discord.SelectOption(
-                        emoji=reaction if reaction is not None else None,
-                        label=getattr(reaction, "name", "\u200b") if reaction is not None else r,
+                        emoji=emoji_val if reaction is not None else None,
+                        label=getattr(reaction, "name", "\u200b")
+                        if reaction is not None
+                        else str(r),
                         value=str(r),
                     ),
                 )

--- a/personalreact/views.py
+++ b/personalreact/views.py
@@ -1,3 +1,4 @@
+import re
 import typing
 
 import discord
@@ -452,10 +453,8 @@ class ReactionsView(discord.ui.View):
             self.remove.options = []
             for r in reactions:
                 reaction = r if isinstance(r, str) else self.ctx.bot.get_emoji(r)
-                # Strip the variation selector (U+FE0F) from plain unicode emoji strings;
-                # Discord's API rejects it in the PartialEmoji.name field (error 50035).
                 emoji_val = (
-                    reaction.rstrip("\N{VARIATION SELECTOR-16}")
+                    re.sub(r"[\ufe0e\ufe0f]", "", reaction)
                     if isinstance(reaction, str)
                     else reaction
                 )


### PR DESCRIPTION
Fixes the following:
```py
#17760 [2026-06-22 19:44:53] ERROR [discord.ui.view] Ignoring exception in view <PersonalReactView timeout=180 children=8> for item <Button style=<ButtonStyle.secondary: 2> url=None disabled=False label='Reactions' emoji=None row=1 sku_id=None id=8>.
Traceback (most recent call last):
File "{HOME}/axion/lib/python3.11/site-packages/discord/ui/view.py", line 598, in _scheduled_task
await item.callback(interaction)
File "{HOME}/data/cogs/CogManager/cogs/personalreact/views.py", line 284, in reactions
await interaction.response.send_message(
File "{HOME}/axion/lib/python3.11/site-packages/discord/interactions.py", line 1085, in send_message
data = await adapter.create_interaction_response(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/axion/lib/python3.11/site-packages/discord/webhook/async_.py", line 226, in request
raise HTTPException(response, data)
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In data.components.1.components.0.options.0.emoji.name: Invalid emoji
```