### PR TITLE
[Dashboard] Fix KeyError with `application_commands`.

### DIFF
--- a/dashboard/rpc/cog_management.py
+++ b/dashboard/rpc/cog_management.py
@@ -124,7 +124,7 @@ class DashboardRPC_CogManagement:
         user_id: int,
     ) -> dict[str, int | dict[str, bool]]:
         if user_id not in self.bot.owner_ids:
-            return {"status": 1}
+            return {"status": 1, "cogs": {}}
         all_cogs = await self.bot._cog_mgr.available_modules()
         loaded_cogs = self.bot.extensions.keys()
         return {
@@ -659,8 +659,10 @@ class DashboardRPC_CogManagement:
         int | dict[str, list[dict[typing.Literal["type", "name"], str]]],
     ]:
         if user_id not in self.bot.owner_ids:
-            return {"status": 1}
+            return {"status": 1, "application_commands": {}}
         command = self.bot.get_command("slash list")
+        if command is None:
+            return {"status": 1, "application_commands": {}}
         callback = command.callback
         content = ""
 


### PR DESCRIPTION
Fix missing `application_commands`/`cogs` keys on RPC failure

`get_application_commands` and `get_cogs` in `cog_management.py` only included their data key when `status == 0`. On the owner check failing (or `slash list` not being found), they'd return e.g. `{"status": 1}` with no `application_commands` key, which reddash indexes directly ; causing an unhandled KeyError/500 instead of a clean error.

Both handlers now always include the key with a `{}` fallback.

Changes were not tested.

Fixes #125

Depends on https://github.com/AAA3A-AAA3A/Red-Web-Dashboard/pull/6