### PR TITLE
[TicketTool] Fix TypeError caused by ruff migration.

### DIFF
--- a/security/modules/message_analysis.py
+++ b/security/modules/message_analysis.py
@@ -182,7 +182,7 @@ class MessageAnalysisModule(Module):
                     hf_path,
                 )
                 self.detoxify_error = False
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.detoxify_error = True
             self.cog.logger.error(f"Failed to load MultilingualDetoxify: {e}", exc_info=e)
 

--- a/tickettool/tickettool.py
+++ b/tickettool/tickettool.py
@@ -670,7 +670,7 @@ class TicketTool(settings, DashboardIntegration, Cog):
         return None
 
     def decorator(
-        self: bool | None = False,
+        ticket_check: bool | None = False,  # noqa: N805
         status: str | None = None,
         ticket_owner: bool | None = False,
         admin_roles: bool | None = False,
@@ -682,9 +682,9 @@ class TicketTool(settings, DashboardIntegration, Cog):
         claim_staff: bool | None = False,
         members: bool | None = False,
         locked: bool | None = None,
-    ) -> None:  # noqa: N805
+    ) -> None:
         async def pred(ctx: commands.Context) -> bool:
-            if not self:
+            if not ticket_check:
                 return True
 
             cog = ctx.bot.get_cog("TicketTool")


### PR DESCRIPTION
Ruff renamed `ticket_check` inside the decorator function as `self`, as of N805. Fixed this back to `ticket_check`, and removed an unused noqa.
Fixes #136 